### PR TITLE
messages for whole system/network configuration

### DIFF
--- a/bm_common_structs.h
+++ b/bm_common_structs.h
@@ -13,6 +13,7 @@ extern "C" {
 typedef enum {
   BM_COMMON_CFG_PARTITION_USER,
   BM_COMMON_CFG_PARTITION_SYSTEM,
+  BM_COMMON_CFG_PARTITION_HARDWARE
 } bm_common_config_partition_e;
 
 typedef struct {

--- a/bm_common_structs.h
+++ b/bm_common_structs.h
@@ -141,7 +141,7 @@ typedef struct {
   // Number of Nodes in the list
   uint16_t num_nodes;
   // List of nodes
-  uint64_t node_list[0];
+  uint64_t list[0];
 } __attribute__((packed)) bm_common_topology_node_list_t;
 
 typedef struct {
@@ -152,7 +152,7 @@ typedef struct {
   // fw info
   bm_common_fw_version_t fw_info;
   // topology list
-  bm_common_topology_node_list_t topology_list;
+  bm_common_topology_node_list_t node_list;
 } __attribute__((packed)) bm_common_network_info_t;
 
 #ifdef __cplusplus

--- a/bm_common_structs.h
+++ b/bm_common_structs.h
@@ -153,7 +153,7 @@ typedef struct {
   bm_common_fw_version_t fw_info;
   // topology list
   bm_common_topology_node_list_t topology_list;
-} __attribute__((packed)) bm_common_network_crc_t;
+} __attribute__((packed)) bm_common_network_info_t;
 
 #ifdef __cplusplus
 }

--- a/bm_common_structs.h
+++ b/bm_common_structs.h
@@ -122,6 +122,35 @@ typedef struct {
     uint8_t data[0];
 } __attribute__((packed)) bm_common_wireless_network_data_header_t;
 
+typedef struct {
+  // crc of the data
+  uint32_t crc32;
+  // Data
+  uint8_t data[0];
+} __attribute__((packed)) bm_common_system_configuration_header_t;
+
+typedef struct {
+  // Partition id
+  bm_common_config_partition_e partition;
+  // Partion crc
+  uint32_t crc32;
+} __attribute__((packed)) bm_common_config_crc_t;
+
+typedef struct {
+  // fw version
+  uint8_t major;
+  uint8_t minor;
+  uint8_t revision;
+  uint32_t gitSHA;
+} __attribute__((packed)) bm_common_fw_version_t;
+
+typedef struct {
+  // Number of Nodes in the list
+  uint16_t num_nodes;
+  // List of nodes
+  uint64_t node_list[0];
+} __attribute__((packed)) bm_common_topology_node_list_t;
+
 #ifdef __cplusplus
 }
 #endif

--- a/bm_common_structs.h
+++ b/bm_common_structs.h
@@ -145,7 +145,7 @@ typedef struct {
 } __attribute__((packed)) bm_common_topology_node_list_t;
 
 typedef struct {
-  // crc of the data
+  // crc of the this message (excluding itself)
   uint32_t newtwork_crc32;
   // Config crc
   bm_common_config_crc_t config_crc;

--- a/bm_common_structs.h
+++ b/bm_common_structs.h
@@ -123,13 +123,6 @@ typedef struct {
 } __attribute__((packed)) bm_common_wireless_network_data_header_t;
 
 typedef struct {
-  // crc of the data
-  uint32_t crc32;
-  // Data
-  uint8_t data[0];
-} __attribute__((packed)) bm_common_network_crc_t;
-
-typedef struct {
   // Partition id
   bm_common_config_partition_e partition;
   // Partion crc
@@ -150,6 +143,17 @@ typedef struct {
   // List of nodes
   uint64_t node_list[0];
 } __attribute__((packed)) bm_common_topology_node_list_t;
+
+typedef struct {
+  // crc of the data
+  uint32_t newtwork_crc32;
+  // Config crc
+  bm_common_config_crc_t config_crc;
+  // fw info
+  bm_common_fw_version_t fw_info;
+  // topology list
+  bm_common_topology_node_list_t topology_list;
+} __attribute__((packed)) bm_common_network_crc_t;
 
 #ifdef __cplusplus
 }

--- a/bm_common_structs.h
+++ b/bm_common_structs.h
@@ -13,7 +13,6 @@ extern "C" {
 typedef enum {
   BM_COMMON_CFG_PARTITION_USER,
   BM_COMMON_CFG_PARTITION_SYSTEM,
-  BM_COMMON_CFG_PARTITION_HARDWARE
 } bm_common_config_partition_e;
 
 typedef struct {

--- a/bm_common_structs.h
+++ b/bm_common_structs.h
@@ -127,7 +127,7 @@ typedef struct {
   uint32_t crc32;
   // Data
   uint8_t data[0];
-} __attribute__((packed)) bm_common_system_configuration_header_t;
+} __attribute__((packed)) bm_common_network_crc_t;
 
 typedef struct {
   // Partition id


### PR DESCRIPTION
for system configuration reporting, the data section of `bm_common_system_configuration_header_t` will consist of [bm_common_config_crc_t, bm_common_fw_version_t, bm_common_topology_node_list_t]