### PR TITLE
Sc 200200/aanderaa wakeup service

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
     -Wextra
     -Werror
     -O0
+    -DCI_TEST
     -g
     )
 message(STATUS "Native compiling - Building Tests")

--- a/device_test_svc_reply_msg.cpp
+++ b/device_test_svc_reply_msg.cpp
@@ -1,0 +1,213 @@
+#include "device_test_svc_reply_msg.h"
+#ifndef CI_TEST
+#include "FreeRTOS.h"
+#endif // CI_TEST
+
+CborError DeviceTestSvcReplyMsg::encode(Data &d, uint8_t *cbor_buffer,
+                                        size_t size, size_t *encoded_len) {
+  CborError err;
+  CborEncoder encoder, map_encoder;
+  cbor_encoder_init(&encoder, cbor_buffer, size, 0);
+
+  do {
+    err = cbor_encoder_create_map(&encoder, &map_encoder, NUM_FIELDS);
+    if (err != CborNoError) {
+      printf("cbor_encoder_create_map failed: %d\n", err);
+      if (err != CborErrorOutOfMemory) {
+        break;
+      }
+    }
+
+    // success
+    err = cbor_encode_text_stringz(&map_encoder, "success");
+    if (err != CborNoError) {
+      printf("cbor_encode_text_stringz failed for success key: %d\n", err);
+      if (err != CborErrorOutOfMemory) {
+        break;
+      }
+    }
+    err = cbor_encode_uint(&map_encoder, d.success);
+    if (err != CborNoError) {
+      printf("cbor_encode_uint failed for partition_id value: %d\n", err);
+      if (err != CborErrorOutOfMemory) {
+        break;
+      }
+    }
+
+    // data_len
+    err = cbor_encode_text_stringz(&map_encoder, "data_len");
+    if (err != CborNoError) {
+      printf("cbor_encode_text_stringz failed for data_len key: %d\n", err);
+      if (err != CborErrorOutOfMemory) {
+        break;
+      }
+    }
+    err = cbor_encode_uint(&map_encoder, d.data_len);
+    if (err != CborNoError) {
+      printf("cbor_encode_uint failed for data_len value: %d\n", err);
+      if (err != CborErrorOutOfMemory) {
+        break;
+      }
+    }
+
+    // data
+    err = cbor_encode_text_stringz(&map_encoder, "data");
+    if (err != CborNoError) {
+      printf("cbor_encode_text_stringz failed for data key: %d\n", err);
+      if (err != CborErrorOutOfMemory) {
+        break;
+      }
+    }
+    err = cbor_encode_byte_string(&map_encoder, d.data, d.data_len);
+    if (err != CborNoError) {
+      printf("cbor_encode_byte_string failed for data value: %d\n", err);
+      if (err != CborErrorOutOfMemory) {
+        break;
+      }
+    }
+
+    if (err != CborNoError && err != CborErrorOutOfMemory) {
+      break;
+    }
+
+    err = cbor_encoder_close_container(&encoder, &map_encoder);
+    if (err == CborNoError) {
+      *encoded_len = cbor_encoder_get_buffer_size(&encoder, cbor_buffer);
+    } else {
+      printf("cbor_encoder_close_container failed: %d\n", err);
+      if (err != CborErrorOutOfMemory) {
+        break;
+      }
+      size_t extra_bytes_needed = cbor_encoder_get_extra_bytes_needed(&encoder);
+      printf("extra_bytes_needed: %zu\n", extra_bytes_needed);
+    }
+  } while (0);
+
+  return err;
+}
+
+CborError DeviceTestSvcReplyMsg::decode(Data &d, const uint8_t *cbor_buffer,
+                                        size_t size) {
+  CborParser parser;
+  CborValue map;
+  CborError err = cbor_parser_init(cbor_buffer, size, 0, &parser, &map);
+  uint64_t tmp_uint64;
+  do {
+    if (err != CborNoError) {
+      break;
+    }
+    err = cbor_value_validate_basic(&map);
+    if (err != CborNoError) {
+      break;
+    }
+    if (!cbor_value_is_map(&map)) {
+      err = CborErrorIllegalType;
+      break;
+    }
+
+    size_t num_fields;
+    err = cbor_value_get_map_length(&map, &num_fields);
+    if (err != CborNoError) {
+      break;
+    }
+    if (num_fields != NUM_FIELDS) {
+      err = CborErrorUnknownLength;
+      printf("expected %zu fields but got %zu\n", NUM_FIELDS, num_fields);
+      break;
+    }
+
+    CborValue value;
+    err = cbor_value_enter_container(&map, &value);
+    if (err != CborNoError) {
+      break;
+    }
+
+    // success
+    if (!cbor_value_is_text_string(&value)) {
+      err = CborErrorIllegalType;
+      printf("expected string key but got something else\n");
+      break;
+    }
+    err = cbor_value_advance(&value);
+    if (err != CborNoError) {
+      break;
+    }
+    err = cbor_value_get_uint64(&value, &tmp_uint64);
+    d.success = static_cast<uint32_t>(tmp_uint64);
+    if (err != CborNoError) {
+      break;
+    }
+    err = cbor_value_advance(&value);
+    if (err != CborNoError) {
+      break;
+    }
+
+    // data_len
+    if (!cbor_value_is_text_string(&value)) {
+      err = CborErrorIllegalType;
+      printf("expected string key but got something else\n");
+      break;
+    }
+    err = cbor_value_advance(&value);
+    if (err != CborNoError) {
+      break;
+    }
+    err = cbor_value_get_uint64(&value, &tmp_uint64);
+    d.data_len = static_cast<uint32_t>(tmp_uint64);
+    if (err != CborNoError) {
+      break;
+    }
+    err = cbor_value_advance(&value);
+    if (err != CborNoError) {
+      break;
+    }
+
+    // data
+    if (!cbor_value_is_text_string(&value)) {
+      err = CborErrorIllegalType;
+      printf("expected string key but got something else\n");
+      break;
+    }
+    err = cbor_value_advance(&value);
+    if (err != CborNoError) {
+      break;
+    }
+    if (d.data_len) {
+      size_t buflen = d.data_len;
+#ifndef CI_TEST
+      uint8_t *buf = static_cast<uint8_t *>(pvPortMalloc(buflen));
+      configASSERT(buf);
+#else
+      uint8_t *buf = static_cast<uint8_t *>(malloc(buflen));
+#endif // CI_TEST
+      err = cbor_value_copy_byte_string(&value, buf, &buflen, NULL);
+      d.data = buf;
+      if (err != CborNoError) {
+        break;
+      }
+      if (buflen != d.data_len) {
+        err = CborErrorIllegalType;
+        break;
+      }
+    } else {
+      d.data = NULL;
+    }
+    err = cbor_value_advance(&value);
+    if (err != CborNoError) {
+      break;
+    }
+
+    if (err == CborNoError) {
+      err = cbor_value_leave_container(&map, &value);
+      if (err != CborNoError) {
+        break;
+      }
+      if (!cbor_value_at_end(&map)) {
+        err = CborErrorGarbageAtEnd;
+        break;
+      }
+    }
+  } while (0);
+
+  return err;
+}

--- a/device_test_svc_reply_msg.cpp
+++ b/device_test_svc_reply_msg.cpp
@@ -1,6 +1,8 @@
 #include "device_test_svc_reply_msg.h"
 #ifndef CI_TEST
 #include "FreeRTOS.h"
+#else // CI_TEST
+#include <cstdlib>
 #endif // CI_TEST
 
 CborError DeviceTestSvcReplyMsg::encode(Data &d, uint8_t *cbor_buffer,

--- a/device_test_svc_reply_msg.h
+++ b/device_test_svc_reply_msg.h
@@ -1,0 +1,19 @@
+#pragma once
+#include "cbor.h"
+
+namespace DeviceTestSvcReplyMsg {
+
+constexpr size_t NUM_FIELDS = 3;
+
+struct Data {
+  bool success;
+  uint32_t data_len;
+  uint8_t *data;
+};
+
+CborError encode(Data &d, uint8_t *cbor_buffer, size_t size,
+                 size_t *encoded_len);
+
+CborError decode(Data &d, const uint8_t *cbor_buffer, size_t size);
+
+} // namespace DeviceTestSvcReplyMsg

--- a/device_test_svc_request_msg.cpp
+++ b/device_test_svc_request_msg.cpp
@@ -1,0 +1,177 @@
+#include "device_test_svc_request_msg.h"
+#ifndef CI_TEST
+#include "FreeRTOS.h"
+#endif // CI_TEST
+
+CborError DeviceTestSvcRequestMsg::encode(Data &d, uint8_t *cbor_buffer,
+                                          size_t size, size_t *encoded_len) {
+  CborError err;
+  CborEncoder encoder, map_encoder;
+  cbor_encoder_init(&encoder, cbor_buffer, size, 0);
+
+  do {
+    err = cbor_encoder_create_map(&encoder, &map_encoder, NUM_FIELDS);
+    if (err != CborNoError) {
+      printf("cbor_encoder_create_map failed: %d\n", err);
+      if (err != CborErrorOutOfMemory) {
+        break;
+      }
+    }
+
+    // data_len
+    err = cbor_encode_text_stringz(&map_encoder, "data_len");
+    if (err != CborNoError) {
+      printf("cbor_encode_text_stringz failed for data_len key: %d\n", err);
+      if (err != CborErrorOutOfMemory) {
+        break;
+      }
+    }
+    err = cbor_encode_uint(&map_encoder, d.data_len);
+    if (err != CborNoError) {
+      printf("cbor_encode_uint failed for data_len value: %d\n", err);
+      if (err != CborErrorOutOfMemory) {
+        break;
+      }
+    }
+
+    // data
+    err = cbor_encode_text_stringz(&map_encoder, "data");
+    if (err != CborNoError) {
+      printf("cbor_encode_text_stringz failed for data key: %d\n", err);
+      if (err != CborErrorOutOfMemory) {
+        break;
+      }
+    }
+    err = cbor_encode_byte_string(&map_encoder, d.data, d.data_len);
+    if (err != CborNoError) {
+      printf("cbor_encode_byte_string failed for data value: %d\n", err);
+      if (err != CborErrorOutOfMemory) {
+        break;
+      }
+    }
+
+    if (err != CborNoError && err != CborErrorOutOfMemory) {
+      break;
+    }
+
+    err = cbor_encoder_close_container(&encoder, &map_encoder);
+    if (err == CborNoError) {
+      *encoded_len = cbor_encoder_get_buffer_size(&encoder, cbor_buffer);
+    } else {
+      printf("cbor_encoder_close_container failed: %d\n", err);
+      if (err != CborErrorOutOfMemory) {
+        break;
+      }
+      size_t extra_bytes_needed = cbor_encoder_get_extra_bytes_needed(&encoder);
+      printf("extra_bytes_needed: %zu\n", extra_bytes_needed);
+    }
+  } while (0);
+
+  return err;
+}
+
+CborError DeviceTestSvcRequestMsg::decode(Data &d, const uint8_t *cbor_buffer,
+                                          size_t size) {
+  CborParser parser;
+  CborValue map;
+  CborError err = cbor_parser_init(cbor_buffer, size, 0, &parser, &map);
+  uint64_t tmp_uint64;
+  do {
+    if (err != CborNoError) {
+      break;
+    }
+    err = cbor_value_validate_basic(&map);
+    if (err != CborNoError) {
+      break;
+    }
+    if (!cbor_value_is_map(&map)) {
+      err = CborErrorIllegalType;
+      break;
+    }
+
+    size_t num_fields;
+    err = cbor_value_get_map_length(&map, &num_fields);
+    if (err != CborNoError) {
+      break;
+    }
+    if (num_fields != NUM_FIELDS) {
+      err = CborErrorUnknownLength;
+      printf("expected %zu fields but got %zu\n", NUM_FIELDS, num_fields);
+      break;
+    }
+
+    CborValue value;
+    err = cbor_value_enter_container(&map, &value);
+    if (err != CborNoError) {
+      break;
+    }
+
+    // data_len
+    if (!cbor_value_is_text_string(&value)) {
+      err = CborErrorIllegalType;
+      printf("expected string key but got something else\n");
+      break;
+    }
+    err = cbor_value_advance(&value);
+    if (err != CborNoError) {
+      break;
+    }
+    err = cbor_value_get_uint64(&value, &tmp_uint64);
+    d.data_len = static_cast<uint32_t>(tmp_uint64);
+    if (err != CborNoError) {
+      break;
+    }
+    err = cbor_value_advance(&value);
+    if (err != CborNoError) {
+      break;
+    }
+
+    // data
+    if (!cbor_value_is_text_string(&value)) {
+      err = CborErrorIllegalType;
+      printf("expected string key but got something else\n");
+      break;
+    }
+    err = cbor_value_advance(&value);
+    if (err != CborNoError) {
+      break;
+    }
+    if (d.data_len) {
+      size_t buflen = d.data_len;
+#ifndef CI_TEST
+      uint8_t *buf = static_cast<uint8_t *>(pvPortMalloc(buflen));
+      configASSERT(buf);
+#else
+      uint8_t *buf = static_cast<uint8_t *>(malloc(buflen));
+#endif // CI_TEST
+      err = cbor_value_copy_byte_string(&value, buf, &buflen, NULL);
+      d.data = buf;
+      if (err != CborNoError) {
+        break;
+      }
+      if (buflen != d.data_len) {
+        err = CborErrorIllegalType;
+        break;
+      }
+    } else {
+      d.data = NULL;
+    }
+    err = cbor_value_advance(&value);
+    if (err != CborNoError) {
+      break;
+    }
+
+    if (err == CborNoError) {
+      err = cbor_value_leave_container(&map, &value);
+      if (err != CborNoError) {
+        break;
+      }
+      if (!cbor_value_at_end(&map)) {
+        err = CborErrorGarbageAtEnd;
+        break;
+      }
+    }
+  } while (0);
+
+  return err;
+}

--- a/device_test_svc_request_msg.cpp
+++ b/device_test_svc_request_msg.cpp
@@ -1,6 +1,8 @@
 #include "device_test_svc_request_msg.h"
 #ifndef CI_TEST
 #include "FreeRTOS.h"
+#else // CI_TEST
+#include <cstdlib>
 #endif // CI_TEST
 
 CborError DeviceTestSvcRequestMsg::encode(Data &d, uint8_t *cbor_buffer,

--- a/device_test_svc_request_msg.h
+++ b/device_test_svc_request_msg.h
@@ -1,0 +1,18 @@
+#pragma once
+#include "cbor.h"
+
+namespace DeviceTestSvcRequestMsg {
+
+constexpr size_t NUM_FIELDS = 2;
+
+struct Data {
+  uint32_t data_len;
+  uint8_t *data;
+};
+
+CborError encode(Data &d, uint8_t *cbor_buffer, size_t size,
+                 size_t *encoded_len);
+
+CborError decode(Data &d, const uint8_t *cbor_buffer, size_t size);
+
+} // namespace DeviceTestSvcRequestMsg

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -20,6 +20,7 @@ target_sources(bm_common_messages_tests
     ${SRC_DIR}/bm_rbr_data_msg.cpp
     ${SRC_DIR}/sensor_header_msg.cpp
     ${SRC_DIR}/device_test_svc_reply_msg.cpp
+    ${SRC_DIR}/device_test_svc_request_msg.cpp
 
     # support files
     ${SRC_DIR}/third_party/tinycbor/src/cborparser.c

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -19,6 +19,7 @@ target_sources(bm_common_messages_tests
     ${SRC_DIR}/bm_soft_data_msg.cpp
     ${SRC_DIR}/bm_rbr_data_msg.cpp
     ${SRC_DIR}/sensor_header_msg.cpp
+    ${SRC_DIR}/device_test_svc_reply_msg.cpp
 
     # support files
     ${SRC_DIR}/third_party/tinycbor/src/cborparser.c

--- a/test/bm_common_messages_tests_ut.cpp
+++ b/test/bm_common_messages_tests_ut.cpp
@@ -8,6 +8,7 @@
 #include "sensor_header_msg.h"
 #include "sys_info_svc_reply_msg.h"
 #include "gtest/gtest.h"
+#include "device_test_svc_reply_msg.h"
 #include <cmath>
 #include <math.h>
 
@@ -127,4 +128,49 @@ TEST_F(BmCommonTest, bmRbrTestTemp) {
   EXPECT_EQ(decode.sensor_type, BmRbrDataMsg::UNKNOWN);
   EXPECT_TRUE(isnan(decode.pressure_deci_bar));
   EXPECT_TRUE(isnan(decode.temperature_deg_c));
+}
+
+TEST_F(BmCommonTest, DeviceTestSvcReplyMsgTestData) {
+  DeviceTestSvcReplyMsg::Data d;
+  d.success = true;
+  d.data_len = 4;
+  d.data = (uint8_t *)malloc(d.data_len);
+  d.data[0] = 0x01;
+  d.data[1] = 0x02;
+  d.data[2] = 0x03;
+  d.data[3] = 0x04;
+
+  uint8_t cbor_buffer[1024];
+  size_t len = 0;
+  EXPECT_EQ(DeviceTestSvcReplyMsg::encode(d, cbor_buffer, sizeof(cbor_buffer), &len), CborNoError);
+  EXPECT_EQ(len, 30);
+
+  DeviceTestSvcReplyMsg::Data decode;
+  EXPECT_EQ(DeviceTestSvcReplyMsg::decode(decode, cbor_buffer, len), CborNoError);
+  EXPECT_EQ(decode.success, true);
+  EXPECT_EQ(decode.data_len, 4);
+  EXPECT_EQ(decode.data[0], 0x01);
+  EXPECT_EQ(decode.data[1], 0x02);
+  EXPECT_EQ(decode.data[2], 0x03);
+  EXPECT_EQ(decode.data[3], 0x04);
+  free(d.data);
+}
+
+TEST_F(BmCommonTest, DeviceTestSvcReplyMsgTestZeroData) {
+  DeviceTestSvcReplyMsg::Data d;
+  d.success = true;
+  d.data_len = 0;
+  d.data = NULL;
+
+  uint8_t cbor_buffer[1024];
+  size_t len = 0;
+  EXPECT_EQ(DeviceTestSvcReplyMsg::encode(d, cbor_buffer, sizeof(cbor_buffer), &len), CborNoError);
+  EXPECT_EQ(len, 26);
+
+  DeviceTestSvcReplyMsg::Data decode;
+  EXPECT_EQ(DeviceTestSvcReplyMsg::decode(decode, cbor_buffer, len), CborNoError);
+  EXPECT_EQ(decode.success, true);
+  EXPECT_EQ(decode.data_len, 0);
+  EXPECT_TRUE(decode.data == NULL);
+  free(d.data);
 }

--- a/test/bm_common_messages_tests_ut.cpp
+++ b/test/bm_common_messages_tests_ut.cpp
@@ -5,10 +5,11 @@
 #include "bm_soft_data_msg.h"
 #include "config_cbor_map_srv_reply_msg.h"
 #include "config_cbor_map_srv_request_msg.h"
+#include "device_test_svc_reply_msg.h"
+#include "device_test_svc_request_msg.h"
 #include "sensor_header_msg.h"
 #include "sys_info_svc_reply_msg.h"
 #include "gtest/gtest.h"
-#include "device_test_svc_reply_msg.h"
 #include <cmath>
 #include <math.h>
 
@@ -134,7 +135,7 @@ TEST_F(BmCommonTest, DeviceTestSvcReplyMsgTestData) {
   DeviceTestSvcReplyMsg::Data d;
   d.success = true;
   d.data_len = 4;
-  d.data = (uint8_t *)malloc(d.data_len);
+  d.data = static_cast<uint8_t *>(malloc(d.data_len));
   d.data[0] = 0x01;
   d.data[1] = 0x02;
   d.data[2] = 0x03;
@@ -142,11 +143,14 @@ TEST_F(BmCommonTest, DeviceTestSvcReplyMsgTestData) {
 
   uint8_t cbor_buffer[1024];
   size_t len = 0;
-  EXPECT_EQ(DeviceTestSvcReplyMsg::encode(d, cbor_buffer, sizeof(cbor_buffer), &len), CborNoError);
+  EXPECT_EQ(
+      DeviceTestSvcReplyMsg::encode(d, cbor_buffer, sizeof(cbor_buffer), &len),
+      CborNoError);
   EXPECT_EQ(len, 30);
 
   DeviceTestSvcReplyMsg::Data decode;
-  EXPECT_EQ(DeviceTestSvcReplyMsg::decode(decode, cbor_buffer, len), CborNoError);
+  EXPECT_EQ(DeviceTestSvcReplyMsg::decode(decode, cbor_buffer, len),
+            CborNoError);
   EXPECT_EQ(decode.success, true);
   EXPECT_EQ(decode.data_len, 4);
   EXPECT_EQ(decode.data[0], 0x01);
@@ -164,12 +168,62 @@ TEST_F(BmCommonTest, DeviceTestSvcReplyMsgTestZeroData) {
 
   uint8_t cbor_buffer[1024];
   size_t len = 0;
-  EXPECT_EQ(DeviceTestSvcReplyMsg::encode(d, cbor_buffer, sizeof(cbor_buffer), &len), CborNoError);
+  EXPECT_EQ(
+      DeviceTestSvcReplyMsg::encode(d, cbor_buffer, sizeof(cbor_buffer), &len),
+      CborNoError);
   EXPECT_EQ(len, 26);
 
   DeviceTestSvcReplyMsg::Data decode;
-  EXPECT_EQ(DeviceTestSvcReplyMsg::decode(decode, cbor_buffer, len), CborNoError);
+  EXPECT_EQ(DeviceTestSvcReplyMsg::decode(decode, cbor_buffer, len),
+            CborNoError);
   EXPECT_EQ(decode.success, true);
+  EXPECT_EQ(decode.data_len, 0);
+  EXPECT_TRUE(decode.data == NULL);
+  free(d.data);
+}
+
+TEST_F(BmCommonTest, DeviceTestSvcRequestMsgTestData) {
+  DeviceTestSvcRequestMsg::Data d;
+  d.data_len = 4;
+  d.data = static_cast<uint8_t *>(malloc(d.data_len));
+  d.data[0] = 0x01;
+  d.data[1] = 0x02;
+  d.data[2] = 0x03;
+  d.data[3] = 0x04;
+
+  uint8_t cbor_buffer[1024];
+  size_t len = 0;
+  EXPECT_EQ(DeviceTestSvcRequestMsg::encode(d, cbor_buffer, sizeof(cbor_buffer),
+                                            &len),
+            CborNoError);
+  EXPECT_EQ(len, 21);
+
+  DeviceTestSvcRequestMsg::Data decode;
+  EXPECT_EQ(DeviceTestSvcRequestMsg::decode(decode, cbor_buffer, len),
+            CborNoError);
+  EXPECT_EQ(decode.data_len, 4);
+  EXPECT_EQ(decode.data[0], 0x01);
+  EXPECT_EQ(decode.data[1], 0x02);
+  EXPECT_EQ(decode.data[2], 0x03);
+  EXPECT_EQ(decode.data[3], 0x04);
+  free(d.data);
+}
+
+TEST_F(BmCommonTest, DeviceTestSvcRequestMsgTestZeroData) {
+  DeviceTestSvcRequestMsg::Data d;
+  d.data_len = 0;
+  d.data = NULL;
+
+  uint8_t cbor_buffer[1024];
+  size_t len = 0;
+  EXPECT_EQ(DeviceTestSvcRequestMsg::encode(d, cbor_buffer, sizeof(cbor_buffer),
+                                            &len),
+            CborNoError);
+  EXPECT_EQ(len, 17);
+
+  DeviceTestSvcRequestMsg::Data decode;
+  EXPECT_EQ(DeviceTestSvcRequestMsg::decode(decode, cbor_buffer, len),
+            CborNoError);
   EXPECT_EQ(decode.data_len, 0);
   EXPECT_TRUE(decode.data == NULL);
   free(d.data);


### PR DESCRIPTION
Adding req/reply cbor framework for the device test service. 

As it pertains to [SC-200200](https://app.shortcut.com/sofar/story/200200/enable-production-testing-tx-to-aanderaa-sensor-on-potted-module?ct_workflow=all), the idea is to have a generic "device testing" service, that calls a user-defined test function, passed in as an argument. 

This messaging req/reply format allows for the passing of arbitrary data which higher level app code can interpret and process. 