### PR TITLE
Config abstraction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,12 +37,27 @@ else()
 # Set target compiler flags with the BM_COMMON_MESSAGES_COMPILER_FLAGS variable
 #
 set(BM_COMMON_MESSAGES_DIR ${CMAKE_CURRENT_LIST_DIR})
-message(status "BM COMMON MESSAGES DIR ${BM_COMMON_MESSAGES_DIR}")
 
-set(BM_COMMON_MESSAGES_INCLUDES
-    ${BM_COMMON_MESSAGES_DIR}
-    )
+set(SOURCES
+    aanderaa_data_msg.cpp
+    bm_rbr_data_msg.cpp
+    bm_rbr_pressure_difference_signal_msg.cpp
+    bm_seapoint_turbidity_data_msg.cpp
+    bm_soft_data_msg.cpp
+    config_cbor_map_srv_reply_msg.c
+    config_cbor_map_srv_request_msg.c
+    device_test_svc_reply_msg.cpp
+    device_test_svc_request_msg.cpp
+    sensor_header_msg.cpp
+    sys_info_svc_reply_msg.c
+)
 
-set(BM_COMMON_MESSAGES_INCLUDES ${BM_COMMON_MESSAGES_INCLUDES} PARENT_SCOPE)
+add_library(bmmessages ${SOURCES})
+
+target_include_directories(bmmessages PUBLIC
+    .
+)
+
+target_link_libraries(bmmessages PRIVATE bmcommon)
 
 endif()

--- a/bm_common_structs.h
+++ b/bm_common_structs.h
@@ -1,20 +1,12 @@
 #pragma once
 
+#include "configuration.h"
 #include <stdbool.h>
 #include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/////////////////////////////
-/* CONFIGURATION*/
-/////////////////////////////
-typedef enum {
-  BM_COMMON_CFG_PARTITION_USER,
-  BM_COMMON_CFG_PARTITION_SYSTEM,
-  BM_COMMON_CFG_PARTITION_HARDWARE,
-} bm_common_config_partition_e;
 
 typedef struct {
   // Node ID of the target node for which the request is being made.
@@ -28,7 +20,7 @@ typedef struct {
 typedef struct {
   bm_common_config_header_t header;
   // Partition id
-  bm_common_config_partition_e partition;
+  BmConfigPartition partition;
   // String length of the key (without terminator)
   uint8_t key_length;
   // Key string
@@ -38,7 +30,7 @@ typedef struct {
 typedef struct {
   bm_common_config_header_t header;
   // Partition id
-  bm_common_config_partition_e partition;
+  BmConfigPartition partition;
   // Length of cbor buffer
   uint32_t data_length;
   // cbor buffer
@@ -48,7 +40,7 @@ typedef struct {
 typedef struct {
   bm_common_config_header_t header;
   // Partition id
-  bm_common_config_partition_e partition;
+  BmConfigPartition partition;
   // String length of the key (without terminator)
   uint8_t key_length;
   // Length of cbor encoded data buffer
@@ -60,13 +52,13 @@ typedef struct {
 typedef struct {
   bm_common_config_header_t header;
   // Partition id
-  bm_common_config_partition_e partition;
+  BmConfigPartition partition;
 } __attribute__((packed)) bm_common_config_commit_t;
 
 typedef struct {
   bm_common_config_header_t header;
   // Partition id
-  bm_common_config_partition_e partition;
+  BmConfigPartition partition;
 } __attribute__((packed)) bm_common_config_status_request_t;
 
 typedef struct {
@@ -79,7 +71,7 @@ typedef struct {
 typedef struct {
   bm_common_config_header_t header;
   // Partition id
-  bm_common_config_partition_e partition;
+  BmConfigPartition partition;
   // True if there are changes to be committed, false otherwise.
   bool committed;
   // Number of keys
@@ -91,7 +83,7 @@ typedef struct {
 typedef struct {
   bm_common_config_header_t header;
   // Partition id
-  bm_common_config_partition_e partition;
+  BmConfigPartition partition;
   // String length of the key (without terminator)
   uint8_t key_length;
   // Key string
@@ -103,7 +95,7 @@ typedef struct {
   // success
   bool success;
   // Partition id
-  bm_common_config_partition_e partition;
+  BmConfigPartition partition;
   // String length of the key (without terminator)
   uint8_t key_length;
   // Key string
@@ -124,7 +116,7 @@ typedef struct {
 
 typedef struct {
   // Partition id
-  bm_common_config_partition_e partition;
+  BmConfigPartition partition;
   // Partion crc
   uint32_t crc32;
 } __attribute__((packed)) bm_common_config_crc_t;


### PR DESCRIPTION
Updates common messages to use type definitions in bm_core to avoid having structures with the same data types defined as different names.
This also build bm_common_messages as a library that can be linked into an application.