### PR TITLE
fix: RBR msg file, ubar -> deci_bar

### DIFF
--- a/msg/bm_rbr_data.msg
+++ b/msg/bm_rbr_data.msg
@@ -3,4 +3,4 @@ import sensor_header
 sensor_header header
 enum sensor_type
 optional float_64 temperature_deg_c
-optional float_64 pressure_ubar
+optional float_64 pressure_deci_bar


### PR DESCRIPTION
Tiny change. These msg files are only informational documentation right now, but eventually we'll want to use them for code generation.

The RmRbrDataMsg::Data code was updated at some point without updating the .msg file. Here's the Data struct from `bm_rbr_data_msg.h`:

```C++
struct Data {
  SensorHeaderMsg::Data header;
  SensorType_t sensor_type;
  double temperature_deg_c;
  double pressure_deci_bar;
};
```