### PR TITLE
Fix Utilization Of Simple Value Decoding And Encoding

### DIFF
--- a/bm_borealis.cpp
+++ b/bm_borealis.cpp
@@ -33,13 +33,15 @@ static CborError send_key_value_float(CborEncoder * map_encoder, const char * na
 
 static CborError send_key_value_uint8(CborEncoder * map_encoder, const char * name, const uint8_t value) {
     CborError err;
+    uint64_t tmp = (uint64_t)value;
+
     if ((err = cbor_encode_text_stringz(map_encoder, name)) != CborNoError) {
         debug_printf("error: %s(%s): cbor_encode_text_stringz() failed: %d\r\n", __func__, name, err);
         if (err != CborErrorOutOfMemory) return err;
     }
 
-    if ((err = cbor_encode_simple_value(map_encoder, value)) != CborNoError)
-        debug_printf("error: %s(%s): cbor_encode_simple_value() failed: %d\r\n", __func__, name, err);
+    if ((err = cbor_encode_uint(map_encoder, tmp)) != CborNoError)
+        debug_printf("error: %s(%s): cbor_encode_uint() failed: %d\r\n", __func__, name, err);
     return err;
 }
 
@@ -173,6 +175,7 @@ static int get_key_value_float(float * out, CborValue * value, const char * key_
 
 static int get_key_value_uint8(uint8_t * out, CborValue * value, const char * key_expected) {
     CborError err;
+    uint64_t tmp = 0;
 
     if (!cbor_value_is_text_string(value)) {
         err = CborErrorIllegalType;
@@ -181,8 +184,10 @@ static int get_key_value_uint8(uint8_t * out, CborValue * value, const char * ke
     }
 
     if ((err = cbor_value_advance(value)) != CborNoError) return -1;
-    if ((err = cbor_value_get_simple_type(value, out)) != CborNoError) return -1;
+    if ((err = cbor_value_get_uint64(value, &tmp)) != CborNoError) return -1;
     if ((err = cbor_value_advance(value)) != CborNoError) return -1;
+
+    *out = (uint8_t)tmp;
 
     return 0;
 }


### PR DESCRIPTION
## What Changed
Fix Utilization Of Simple Value Decoding And Encoding.
This is was replaced with `cbor_value_get_uint64` and `cbor_encode_uint` respectively and then cast/assigned to uint8 values.


## Why?
Cbor simple value does not encode uint8 but is instead supposed to be used to encode bool, NULL pointers and other objects that have a specific codes (see `CborSimpleTypes` in `cborinternal_p.h`).

When a simple type value is 25(`HalfPrecisionFloat`) and 31(`Break` )it sets messes things up when decoding the message..., when decoding, we see that this is as an improper value and return `CborErrorIllegalSimpleType` when determining if the message is valid.

If `bands_per_octave` is set between 25 and 31 the decoder will fail to decode the message.

This is not very clear from the doxygen like comments on the function `cbor_encode_simple_value`:

```
/**
 * Appends the CBOR Simple Type of value \a value to the CBOR stream provided by
 * \a encoder.
 *
 * This function may return error CborErrorIllegalSimpleType if the \a value
 * variable contains a number that is not a valid simple type.
 */
 CborError cbor_encode_simple_value(CborEncoder *encoder, uint8_t value)
```

 Upon further research I have found the following (Gemini AI generated):

> A CBOR simple type is a simple object in the Concise Binary Object Representation (CBOR) data format that has a major type of CborMajorType.OTHER and no additional data. 
> Examples of CBOR simple types     
> 
> - **Boolean**: A simple value with a value of 21 for true or 20 for false 
> - **Null**: A simple value with a value of 22 
> 
>        CBOR simple value object class     
> 
> - The CBOR simple value object class in CborTree is used to represent CBOR simple types 
> - Untagged instances are always singletons, so you can directly compare known-untagged instances to any other CborSimple instance 
> 
>        CBOR data format    
> 
> - CBOR is a binary data format that's designed to be easy to implement, compact, and light on CPU usage 
> - It's convertible to and from JSON
> - CBOR's design goals include small code size, small message size, and extensibility 

Reference:
https://www.w3.org/TR/did-cbor-representation/
