### PR TITLE
feat: add salinity to PME DO message

### DIFF
--- a/msg/pme_dissolved_oxygen.msg
+++ b/msg/pme_dissolved_oxygen.msg
@@ -1,7 +1,8 @@
 import sensor_header
 
 sensor_header header
-float_64 temperature_deg_c
-float_64 do_mg_per_l
-float_64 quality
-float_64 do_saturation_pct
+float64 temperature_deg_c
+float64 do_mg_per_l
+float64 quality
+float64 do_saturation_pct
+float32 salinity_ppt

--- a/pme_dissolved_oxygen_msg.cpp
+++ b/pme_dissolved_oxygen_msg.cpp
@@ -31,8 +31,9 @@ CborError encode(Data &d, uint8_t *cbor_buffer, size_t size,
     // temperature_deg_c
     err = cbor_encode_text_stringz(&map_encoder, "temperature_deg_c");
     if (err != CborNoError) {
-      bm_debug("cbor_encode_text_stringz failed for temperature_deg_c key: %d\n",
-             err);
+      bm_debug(
+          "cbor_encode_text_stringz failed for temperature_deg_c key: %d\n",
+          err);
       if (err != CborErrorOutOfMemory) {
         break;
       }
@@ -40,7 +41,7 @@ CborError encode(Data &d, uint8_t *cbor_buffer, size_t size,
     err = cbor_encode_double(&map_encoder, d.temperature_deg_c);
     if (err != CborNoError) {
       bm_debug("cbor_encode_double failed for temperature_deg_c value: %d\n",
-             err);
+               err);
       if (err != CborErrorOutOfMemory) {
         break;
       }
@@ -50,15 +51,14 @@ CborError encode(Data &d, uint8_t *cbor_buffer, size_t size,
     err = cbor_encode_text_stringz(&map_encoder, "do_mg_per_l");
     if (err != CborNoError) {
       bm_debug("cbor_encode_text_stringz failed for do_mg_per_l key: %d\n",
-             err);
+               err);
       if (err != CborErrorOutOfMemory) {
         break;
       }
     }
     err = cbor_encode_double(&map_encoder, d.do_mg_per_l);
     if (err != CborNoError) {
-      bm_debug("cbor_encode_double failed for do_mg_per_l value: %d\n",
-             err);
+      bm_debug("cbor_encode_double failed for do_mg_per_l value: %d\n", err);
       if (err != CborErrorOutOfMemory) {
         break;
       }
@@ -67,16 +67,14 @@ CborError encode(Data &d, uint8_t *cbor_buffer, size_t size,
     // quality
     err = cbor_encode_text_stringz(&map_encoder, "quality");
     if (err != CborNoError) {
-      bm_debug("cbor_encode_text_stringz failed for quality key: %d\n",
-             err);
+      bm_debug("cbor_encode_text_stringz failed for quality key: %d\n", err);
       if (err != CborErrorOutOfMemory) {
         break;
       }
     }
     err = cbor_encode_double(&map_encoder, d.quality);
     if (err != CborNoError) {
-      bm_debug("cbor_encode_double failed for quality value: %d\n",
-             err);
+      bm_debug("cbor_encode_double failed for quality value: %d\n", err);
       if (err != CborErrorOutOfMemory) {
         break;
       }
@@ -85,8 +83,9 @@ CborError encode(Data &d, uint8_t *cbor_buffer, size_t size,
     // do_saturation_pct
     err = cbor_encode_text_stringz(&map_encoder, "do_saturation_pct");
     if (err != CborNoError) {
-      bm_debug("cbor_encode_text_stringz failed for do_saturation_pct key: %d\n",
-             err);
+      bm_debug(
+          "cbor_encode_text_stringz failed for do_saturation_pct key: %d\n",
+          err);
       if (err != CborErrorOutOfMemory) {
         break;
       }
@@ -94,7 +93,24 @@ CborError encode(Data &d, uint8_t *cbor_buffer, size_t size,
     err = cbor_encode_double(&map_encoder, d.do_saturation_pct);
     if (err != CborNoError) {
       bm_debug("cbor_encode_double failed for do_saturation_pct value: %d\n",
-             err);
+               err);
+      if (err != CborErrorOutOfMemory) {
+        break;
+      }
+    }
+
+    // salinity_ppt
+    err = cbor_encode_text_stringz(&map_encoder, "salinity_ppt");
+    if (err != CborNoError) {
+      bm_debug("cbor_encode_text_stringz failed for salinity_ppt key: %d\n",
+               err);
+      if (err != CborErrorOutOfMemory) {
+        break;
+      }
+    }
+    err = cbor_encode_float(&map_encoder, d.salinity_ppt);
+    if (err != CborNoError) {
+      bm_debug("cbor_encode_float failed for salinity_ppt value: %d\n", err);
       if (err != CborErrorOutOfMemory) {
         break;
       }
@@ -226,6 +242,25 @@ CborError decode(Data &d, const uint8_t *cbor_buffer, size_t size) {
       break;
     }
     err = cbor_value_get_double(&value, &d.do_saturation_pct);
+    if (err != CborNoError) {
+      break;
+    }
+    err = cbor_value_advance(&value);
+    if (err != CborNoError) {
+      break;
+    }
+
+    // salinity_ppt
+    if (!cbor_value_is_text_string(&value)) {
+      err = CborErrorIllegalType;
+      bm_debug("expected string key but got something else\n");
+      break;
+    }
+    err = cbor_value_advance(&value);
+    if (err != CborNoError) {
+      break;
+    }
+    err = cbor_value_get_float(&value, &d.salinity_ppt);
     if (err != CborNoError) {
       break;
     }

--- a/pme_dissolved_oxygen_msg.h
+++ b/pme_dissolved_oxygen_msg.h
@@ -7,7 +7,7 @@
 namespace PmeDissolvedOxygenMsg {
 
 constexpr uint32_t VERSION = 1;
-constexpr size_t NUM_FIELDS = 4 + SensorHeaderMsg::NUM_FIELDS;
+constexpr size_t NUM_FIELDS = 5 + SensorHeaderMsg::NUM_FIELDS;
 
 struct Data {
   SensorHeaderMsg::Data header;
@@ -15,6 +15,7 @@ struct Data {
   double do_mg_per_l;
   double quality;
   double do_saturation_pct;
+  float salinity_ppt;
 };
 
 CborError encode(Data &d, uint8_t *cbor_buffer, size_t size,

--- a/test/bm_common_messages_tests_ut.cpp
+++ b/test/bm_common_messages_tests_ut.cpp
@@ -376,11 +376,12 @@ TEST_F(BmCommonTest, PmeDissolvedOxygenMsgTest) {
   d.do_mg_per_l = 7.891;
   d.quality = 0.987;
   d.do_saturation_pct = 100.0;
+  d.salinity_ppt = 32.0;
 
   uint8_t cbor_buffer[1024];
   size_t len = 0;
   PmeDissolvedOxygenMsg::encode(d, cbor_buffer, sizeof(cbor_buffer), &len);
-  EXPECT_EQ(len, 182);
+  EXPECT_EQ(len, 200);
 
   PmeDissolvedOxygenMsg::Data decode;
   PmeDissolvedOxygenMsg::decode(decode, cbor_buffer, len);
@@ -392,6 +393,7 @@ TEST_F(BmCommonTest, PmeDissolvedOxygenMsgTest) {
   EXPECT_EQ(decode.do_mg_per_l, 7.891);
   EXPECT_EQ(decode.quality, 0.987);
   EXPECT_EQ(decode.do_saturation_pct, 100.0);
+  EXPECT_EQ(decode.salinity_ppt, 32.0);
 }
 
 TEST_F(BmCommonTest, PmeWipeMsgTest) {


### PR DESCRIPTION
Made these changes in a live trio-coding session with @b-haist and Peter from PME. The codec changes were test-driven!

Summary:
- Add salinity_ppt float to the Data struct and the ROS-style msg documentation
- Encode the salinity_ppt field
- Decode the salinity_ppt field
- Test the codec
- Some clang-format whitespace changes