### PR TITLE
added depth_m in the cbor message

### DIFF
--- a/aanderaa_conductivity_msg.cpp
+++ b/aanderaa_conductivity_msg.cpp
@@ -112,6 +112,22 @@ namespace AanderaaConductivityMsg {
                 }
             }
 
+            // depth_m
+            err = cbor_encode_text_stringz(&map_encoder, "depth_m");
+            if (err != CborNoError) {
+                bm_debug("cbor_encode_text_stingz failed for depth_m key: %d\n", err);
+                if (err != CborErrorOutOfMemory) {
+                    break;
+                }
+            }
+            err = cbor_encode_float(&map_encoder, d.depth_m);
+            if (err != CborNoError) {
+                bm_debug("cbor_encode_float failed for depth_m value: %d\n", err);
+                if (err != CborErrorOutOfMemory) {
+                    break;
+                }
+            }
+
             err = cbor_encoder_close_container(&encoder, &map_encoder);
             if (err == CborNoError) {
                 *encoded_len = cbor_encoder_get_buffer_size(&encoder, cbor_buffer);
@@ -257,6 +273,25 @@ namespace AanderaaConductivityMsg {
                 break;
             }
             err = cbor_value_get_double(&value, &d.sound_speed_m_s);
+            if (err != CborNoError) {
+                break;
+            }
+            err = cbor_value_advance(&value);
+            if (err != CborNoError) {
+                break;
+            }
+
+            // depth_m
+            if (!cbor_value_is_text_string(&value)) {
+                err = CborErrorIllegalType;
+                bm_debug("expected string key but got something else\n");
+                break;
+            }
+            err = cbor_value_advance(&value);
+            if (err != CborNoError) {
+                break;
+            }
+            err = cbor_value_get_float(&value, &d.depth_m);
             if (err != CborNoError) {
                 break;
             }

--- a/aanderaa_conductivity_msg.h
+++ b/aanderaa_conductivity_msg.h
@@ -7,7 +7,7 @@
 namespace AanderaaConductivityMsg {
 
     constexpr uint32_t VERSION = 1;
-    constexpr size_t NUM_FIELDS = 5 + SensorHeaderMsg::NUM_FIELDS;
+    constexpr size_t NUM_FIELDS = 6 + SensorHeaderMsg::NUM_FIELDS;
 
     struct Data {
         SensorHeaderMsg::Data header;
@@ -16,6 +16,7 @@ namespace AanderaaConductivityMsg {
         double salinity_psu;
         double water_density_kg_m3;
         double sound_speed_m_s;
+        float depth_m;
     };
 
     CborError encode(Data &d, uint8_t *cbor_buffer, size_t size,

--- a/msg/aanderaa_conductivity_data.msg
+++ b/msg/aanderaa_conductivity_data.msg
@@ -6,3 +6,4 @@ float64 temperature_deg_c
 float64 salinity_psu
 float64 water_density_kg_m3
 float64 sound_speed_m_s
+float32 depth_m

--- a/test/bm_common_messages_tests_ut.cpp
+++ b/test/bm_common_messages_tests_ut.cpp
@@ -462,11 +462,12 @@ TEST_F(BmCommonTest, AanderaaConductivityTest) {
     d.salinity_psu = 35.123;
     d.water_density_kg_m3 = 1025.83;
     d.sound_speed_m_s = 1498.15;
+    d.depth_m = 10.0;
 
     uint8_t cbor_buffer[1024];
     size_t len = 0;
     AanderaaConductivityMsg::encode(d, cbor_buffer, sizeof(cbor_buffer), &len);
-    EXPECT_EQ(len, 221);
+    EXPECT_EQ(len, 234);
 
     AanderaaConductivityMsg::Data decode;
     AanderaaConductivityMsg::decode(decode, cbor_buffer, len);
@@ -479,6 +480,7 @@ TEST_F(BmCommonTest, AanderaaConductivityTest) {
     EXPECT_EQ(decode.salinity_psu, 35.123);
     EXPECT_EQ(decode.water_density_kg_m3, 1025.83);
     EXPECT_EQ(decode.sound_speed_m_s, 1498.15);
+    EXPECT_EQ(decode.depth_m, 10.0);
 }
 
 TEST_F(BmCommonTest, AanderaaCurrentMeterTest) {


### PR DESCRIPTION
Added `depth_m` after getting the [BM product spec - Aanderaa Conductivity Module](https://www.notion.so/sofarocean/BM-product-spec-Aanderaa-Conductivity-Module-2408ff95945080c2a647f759620c55c5) doc reviewed.