### PR TITLE
Bring device test svc in line with CI_TEST conventions

### DIFF
--- a/device_test_svc_reply_msg.cpp
+++ b/device_test_svc_reply_msg.cpp
@@ -1,10 +1,10 @@
 #include "device_test_svc_reply_msg.h"
 #include "bm_config.h"
-#ifndef CI_TEST
+#if !defined(CI_TEST) && !defined(BM_HOSTED)
 #include "FreeRTOS.h"
-#else // CI_TEST
+#else
 #include <cstdlib>
-#endif // CI_TEST
+#endif
 
 CborError DeviceTestSvcReplyMsg::encode(Data &d, uint8_t *cbor_buffer,
                                         size_t size, size_t *encoded_len) {
@@ -177,12 +177,12 @@ CborError DeviceTestSvcReplyMsg::decode(Data &d, const uint8_t *cbor_buffer,
     }
     if (d.data_len) {
       size_t buflen = d.data_len;
-#ifndef CI_TEST
+#if !defined(CI_TEST) && !defined(BM_HOSTED)
       uint8_t *buf = static_cast<uint8_t *>(pvPortMalloc(buflen));
       configASSERT(buf);
 #else
       uint8_t *buf = static_cast<uint8_t *>(malloc(buflen));
-#endif // CI_TEST
+#endif
       err = cbor_value_copy_byte_string(&value, buf, &buflen, NULL);
       d.data = buf;
       if (err != CborNoError) {

--- a/device_test_svc_reply_msg.cpp
+++ b/device_test_svc_reply_msg.cpp
@@ -1,9 +1,7 @@
 #include "device_test_svc_reply_msg.h"
 #include "bm_config.h"
-#if !defined(CI_TEST) && !defined(BM_HOSTED)
-#include "FreeRTOS.h"
-#else
-#include <cstdlib>
+#ifndef CI_TEST
+#include "bm_os.h"
 #endif
 
 CborError DeviceTestSvcReplyMsg::encode(Data &d, uint8_t *cbor_buffer,
@@ -177,9 +175,8 @@ CborError DeviceTestSvcReplyMsg::decode(Data &d, const uint8_t *cbor_buffer,
     }
     if (d.data_len) {
       size_t buflen = d.data_len;
-#if !defined(CI_TEST) && !defined(BM_HOSTED)
-      uint8_t *buf = static_cast<uint8_t *>(pvPortMalloc(buflen));
-      configASSERT(buf);
+#ifndef CI_TEST
+      uint8_t *buf = static_cast<uint8_t *>(bm_malloc(buflen));
 #else
       uint8_t *buf = static_cast<uint8_t *>(malloc(buflen));
 #endif

--- a/device_test_svc_request_msg.cpp
+++ b/device_test_svc_request_msg.cpp
@@ -1,9 +1,7 @@
 #include "device_test_svc_request_msg.h"
 #include "bm_config.h"
-#if !defined(CI_TEST) && !defined(BM_HOSTED)
-#include "FreeRTOS.h"
-#else
-#include <cstdlib>
+#ifndef CI_TEST
+#include "bm_os.h"
 #endif
 
 CborError DeviceTestSvcRequestMsg::encode(Data &d, uint8_t *cbor_buffer,
@@ -141,9 +139,8 @@ CborError DeviceTestSvcRequestMsg::decode(Data &d, const uint8_t *cbor_buffer,
     }
     if (d.data_len) {
       size_t buflen = d.data_len;
-#if !defined(CI_TEST) && !defined(BM_HOSTED)
-      uint8_t *buf = static_cast<uint8_t *>(pvPortMalloc(buflen));
-      configASSERT(buf);
+#ifndef CI_TEST
+      uint8_t *buf = static_cast<uint8_t *>(bm_malloc(buflen));
 #else
       uint8_t *buf = static_cast<uint8_t *>(malloc(buflen));
 #endif

--- a/device_test_svc_request_msg.cpp
+++ b/device_test_svc_request_msg.cpp
@@ -1,10 +1,10 @@
 #include "device_test_svc_request_msg.h"
 #include "bm_config.h"
-#ifndef CI_TEST
+#if !defined(CI_TEST) && !defined(BM_HOSTED)
 #include "FreeRTOS.h"
-#else // CI_TEST
+#else
 #include <cstdlib>
-#endif // CI_TEST
+#endif
 
 CborError DeviceTestSvcRequestMsg::encode(Data &d, uint8_t *cbor_buffer,
                                           size_t size, size_t *encoded_len) {
@@ -141,12 +141,12 @@ CborError DeviceTestSvcRequestMsg::decode(Data &d, const uint8_t *cbor_buffer,
     }
     if (d.data_len) {
       size_t buflen = d.data_len;
-#ifndef CI_TEST
+#if !defined(CI_TEST) && !defined(BM_HOSTED)
       uint8_t *buf = static_cast<uint8_t *>(pvPortMalloc(buflen));
       configASSERT(buf);
 #else
       uint8_t *buf = static_cast<uint8_t *>(malloc(buflen));
-#endif // CI_TEST
+#endif
       err = cbor_value_copy_byte_string(&value, buf, &buflen, NULL);
       d.data = buf;
       if (err != CborNoError) {


### PR DESCRIPTION
Experimenting with bm_core on RPi. This minor issue came up in that work. Claude initially added a new build flag that wasn't necessary. I've cleaned it up to follow the convention in the borealis test where malloc is also needed.

This PR is a dependency of https://github.com/bristlemouth/bm_core/pull/122