### PR TITLE
Feature/power solar averages reading msg

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,7 @@ set(SOURCES
     power_reading_msg.cpp
     power_reading_averages_msg.cpp
     power_solar_reading_msg.cpp
+    power_solar_averages_msg.cpp
     sensor_header_msg.cpp
     sensor_header_msg.c
     sys_info_svc_reply_msg.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,7 @@ set(SOURCES
     power_battery_averages_msg.cpp
     power_reading_msg.cpp
     power_reading_averages_msg.cpp
+    power_solar_reading_msg.cpp
     sensor_header_msg.cpp
     sensor_header_msg.c
     sys_info_svc_reply_msg.c

--- a/msg/power_solar_averages.msg
+++ b/msg/power_solar_averages.msg
@@ -1,0 +1,17 @@
+import sensor_header
+
+sensor_header header
+uint32 num_samples
+float64 averaging_window_length_s
+float64 panel_temperatures_average[]    # Array of averaged temperatures, one for each temp sensor in the panel/cell array
+float64 panel_temperatures_max[]        # Array of max temperatures, one for each temp sensor in the panel/cell array
+float64 panel_temperatures_min[]        # Array of min temperatures, one for each temp sensor in the panel/cell array
+float64 panel_temperatures_stdev[]      # Array of stdev temperatures, one for each temp sensor in the panel/cell array
+float64 panel_voltages_average[]        # Array of averaged voltages, one for each isolated line in the array
+float64 panel_voltages_max[]            # Array of max voltages, one for each isolated line in the array
+float64 panel_voltages_min[]            # Array of min voltages, one for each isolated line in the array
+float64 panel_voltages_stdev[]          # Array of stdev voltages, one for each isolated line in the array
+float64 panel_currents_average[]        # Array of average currents, one for each isolated line in the array
+float64 panel_currents_max[]            # Array of max currents, one for each isolated line in the array
+float64 panel_currents_min[]            # Array of min currents, one for each isolated line in the array
+float64 panel_currents_stdev[]          # Array of stdev currents, one for each isolated line in the array

--- a/msg/power_solar_averages.msg
+++ b/msg/power_solar_averages.msg
@@ -1,6 +1,8 @@
 import sensor_header
 
 sensor_header header
+uint8 power_reading_type
+uint8 status
 uint32 num_samples
 float64 averaging_window_length_s
 float64 panel_temperatures_average[]    # Array of averaged temperatures, one for each temp sensor in the panel/cell array

--- a/msg/power_solar_reading.msg
+++ b/msg/power_solar_reading.msg
@@ -6,7 +6,6 @@ float64 voltage_v
 float64 current_a
 uint8 status
 float64 mpp_position            # Where is power generation relative to Max Power Point of panel at current temp/age, as %.
-uint8 num_panels
 float64 panel_temperatures[]    # Array of temperatures, one for each temp sensor in the panel/cell array
 float64 panel_voltages[]        # Array of voltages, one for each isolated line in the array
-float64 panel_currents[]        # ditto
+float64 panel_currents[]        # Array of current, on for each isoltaed line in the array

--- a/msg/power_solar_reading.msg
+++ b/msg/power_solar_reading.msg
@@ -1,0 +1,12 @@
+import sensor_header
+
+sensor_header header
+uint8 power_reading_type
+float64 voltage_v
+float64 current_a
+uint8 status
+float64 mpp_position            # Where is power generation relative to Max Power Point of panel at current temp/age, as %.
+uint8 num_panels
+float64 panel_temperatures[]    # Array of temperatures, one for each temp sensor in the panel/cell array
+float64 panel_voltages[]        # Array of voltages, one for each isolated line in the array
+float64 panel_currents[]        # ditto

--- a/msg/power_solar_reading.msg
+++ b/msg/power_solar_reading.msg
@@ -5,7 +5,6 @@ uint8 power_reading_type
 float64 voltage_v
 float64 current_a
 uint8 status
-float64 mpp_position            # Where is power generation relative to Max Power Point of panel at current temp/age, as %.
 float64 panel_temperatures[]    # Array of temperatures, one for each temp sensor in the panel/cell array
 float64 panel_voltages[]        # Array of voltages, one for each isolated line in the array
 float64 panel_currents[]        # Array of current, on for each isoltaed line in the array

--- a/power_battery_averages_msg.cpp
+++ b/power_battery_averages_msg.cpp
@@ -84,7 +84,7 @@ CborError PowerBatteryAveragesMsg::encode(Data &d, uint8_t *cbor_buffer, size_t 
  array will be skipped during decoding.
 
  **CALLER RESPONSIBILITY**: The caller is responsible for freeing all allocated array
- memory when no longer needed using bm_free().
+ memory when no longer needed using bm_free() or the provided PowerBatteryAveragesMsg::free.
 
  @param d Reference to Data structure to populate. Array pointers must be NULL.
  @param cbor_buffer Pointer to the CBOR-encoded message buffer

--- a/power_solar_averages_msg.cpp
+++ b/power_solar_averages_msg.cpp
@@ -1,0 +1,171 @@
+#include "power_solar_averages_msg.h"
+#include "bm_config.h"
+#include "bm_messages_helper.h"
+#ifndef CI_TEST
+#include "bm_os.h"
+#endif
+
+CborError PowerSolarAveragesMsg::encode(Data &d, uint8_t *cbor_buffer, size_t size,
+                                        size_t *encoded_len) {
+  CborError err;
+  CborEncoder encoder, map_encoder;
+
+  err = encoder_message_create(&encoder, &map_encoder, cbor_buffer, size,
+                               PowerSolarAveragesMsg::NUM_FIELDS);
+
+  // sensor_header_msg
+  err = SensorHeaderMsg::encode(map_encoder, d.header);
+  if (err != CborNoError) {
+    bm_debug("SensorHeaderMsg::encode failed: %d\n", err);
+    if (err != CborErrorOutOfMemory) {
+      return err;
+    }
+  }
+
+  check_and_encode_key(err, encode_key_value_uint32(&map_encoder,
+                                                    PowerSolarAveragesMsg::NUM_SAMPLES,
+                                                    d.num_samples));
+  check_and_encode_key(
+      err,
+      encode_key_value_double(&map_encoder, PowerSolarAveragesMsg::AVERAGING_WINDOW_LENGTH_S,
+                              d.averaging_window_length_s));
+  check_and_encode_key(err, encode_key_value_double_array(
+                                &map_encoder, PowerSolarAveragesMsg::PANEL_TEMPERATURES_AVERAGE,
+                                d.panel_temperatures_average, d.num_temp_sensors));
+  check_and_encode_key(err, encode_key_value_double_array(
+                                &map_encoder, PowerSolarAveragesMsg::PANEL_TEMPERATURES_MAX,
+                                d.panel_temperatures_max, d.num_temp_sensors));
+  check_and_encode_key(err, encode_key_value_double_array(
+                                &map_encoder, PowerSolarAveragesMsg::PANEL_TEMPERATURES_MIN,
+                                d.panel_temperatures_min, d.num_temp_sensors));
+  check_and_encode_key(err, encode_key_value_double_array(
+                                &map_encoder, PowerSolarAveragesMsg::PANEL_TEMPERATURES_STDEV,
+                                d.panel_temperatures_stdev, d.num_temp_sensors));
+  check_and_encode_key(err, encode_key_value_double_array(
+                                &map_encoder, PowerSolarAveragesMsg::PANEL_VOLTAGES_AVERAGE,
+                                d.panel_voltages_average, d.num_lines));
+  check_and_encode_key(err, encode_key_value_double_array(
+                                &map_encoder, PowerSolarAveragesMsg::PANEL_VOLTAGES_MAX,
+                                d.panel_voltages_max, d.num_lines));
+  check_and_encode_key(err, encode_key_value_double_array(
+                                &map_encoder, PowerSolarAveragesMsg::PANEL_VOLTAGES_MIN,
+                                d.panel_voltages_min, d.num_lines));
+  check_and_encode_key(err, encode_key_value_double_array(
+                                &map_encoder, PowerSolarAveragesMsg::PANEL_VOLTAGES_STDEV,
+                                d.panel_voltages_stdev, d.num_lines));
+  check_and_encode_key(err, encode_key_value_double_array(
+                                &map_encoder, PowerSolarAveragesMsg::PANEL_CURRENTS_AVERAGE,
+                                d.panel_currents_average, d.num_lines));
+  check_and_encode_key(err, encode_key_value_double_array(
+                                &map_encoder, PowerSolarAveragesMsg::PANEL_CURRENTS_MAX,
+                                d.panel_currents_max, d.num_lines));
+  check_and_encode_key(err, encode_key_value_double_array(
+                                &map_encoder, PowerSolarAveragesMsg::PANEL_CURRENTS_MIN,
+                                d.panel_currents_min, d.num_lines));
+  check_and_encode_key(err, encode_key_value_double_array(
+                                &map_encoder, PowerSolarAveragesMsg::PANEL_CURRENTS_STDEV,
+                                d.panel_currents_stdev, d.num_lines));
+
+  if (check_acceptable_encode_errors(err)) {
+    err = encoder_message_finish(&encoder, &map_encoder);
+    *encoded_len = cbor_encoder_get_buffer_size(&encoder, cbor_buffer);
+  }
+
+  encoder_message_check_memory(&encoder, err);
+
+  return err;
+}
+
+/*!
+ @brief Decodes a PowerSolarAveragesMsg from a CBOR buffer
+
+ @details This function decodes a CBOR-encoded PowerSolarAveragesMsg and populates
+ the provided Data structure. It decodes the sensor header, simple fields, and
+ dynamically sized arrays for panel temperature, voltage, and current statistics.
+
+ **MEMORY ALLOCATION**: This function allocates memory for all array fields in the
+ Data structure using bm_malloc().
+
+ **REQUIREMENTS**: All array pointer fields in the Data structure MUST be initialized
+ to NULL before calling this function. If an array pointer is already non-NULL, that
+ array will be skipped during decoding.
+
+ **CALLER RESPONSIBILITY**: The caller is responsible for freeing all allocated array
+ memory when no longer needed using bm_free().
+
+ @param d Reference to Data structure to populate. Array pointers must be NULL.
+ @param cbor_buffer Pointer to the CBOR-encoded message buffer
+ @param size Size of the CBOR buffer in bytes
+
+ @return CborError - CborNoError on success, or appropriate error code:
+         - CborErrorIllegalType if unexpected CBOR types are encountered
+         - CborErrorOutOfMemory if memory allocation fails
+         - Other CBOR errors from underlying decode operations
+ */
+CborError PowerSolarAveragesMsg::decode(Data &d, const uint8_t *cbor_buffer, size_t size) {
+  CborParser parser;
+  CborValue map, value;
+  CborError err;
+
+  err = decoder_message_enter(&map, &value, &parser, (uint8_t *)cbor_buffer, size,
+                              PowerSolarAveragesMsg::NUM_FIELDS);
+  if (err != CborNoError) {
+    return err;
+  }
+
+  // decode header
+  err = SensorHeaderMsg::decode(value, d.header);
+  if (err != CborNoError) {
+    return err;
+  }
+
+  check_and_decode_key(err, decode_key_value_uint32(&d.num_samples, &value,
+                                                    PowerSolarAveragesMsg::NUM_SAMPLES));
+  check_and_decode_key(
+      err, decode_key_value_double(&d.averaging_window_length_s, &value,
+                                   PowerSolarAveragesMsg::AVERAGING_WINDOW_LENGTH_S));
+  // decode the arrays
+  check_and_decode_key(
+      err,
+      decode_key_value_double_array(&d.panel_temperatures_average, &d.num_temp_sensors, &value,
+                                    PowerSolarAveragesMsg::PANEL_TEMPERATURES_AVERAGE));
+  check_and_decode_key(
+      err, decode_key_value_double_array(&d.panel_temperatures_max, &d.num_temp_sensors, &value,
+                                         PowerSolarAveragesMsg::PANEL_TEMPERATURES_MAX));
+  check_and_decode_key(
+      err, decode_key_value_double_array(&d.panel_temperatures_min, &d.num_temp_sensors, &value,
+                                         PowerSolarAveragesMsg::PANEL_TEMPERATURES_MIN));
+  check_and_decode_key(
+      err, decode_key_value_double_array(&d.panel_temperatures_stdev, &d.num_temp_sensors, &value,
+                                         PowerSolarAveragesMsg::PANEL_TEMPERATURES_STDEV));
+  check_and_decode_key(
+      err, decode_key_value_double_array(&d.panel_voltages_average, &d.num_lines, &value,
+                                         PowerSolarAveragesMsg::PANEL_VOLTAGES_AVERAGE));
+  check_and_decode_key(
+      err, decode_key_value_double_array(&d.panel_voltages_max, &d.num_lines, &value,
+                                         PowerSolarAveragesMsg::PANEL_VOLTAGES_MAX));
+  check_and_decode_key(
+      err, decode_key_value_double_array(&d.panel_voltages_min, &d.num_lines, &value,
+                                         PowerSolarAveragesMsg::PANEL_VOLTAGES_MIN));
+  check_and_decode_key(
+      err, decode_key_value_double_array(&d.panel_voltages_stdev, &d.num_lines, &value,
+                                         PowerSolarAveragesMsg::PANEL_VOLTAGES_STDEV));
+  check_and_decode_key(
+      err, decode_key_value_double_array(&d.panel_currents_average, &d.num_lines, &value,
+                                         PowerSolarAveragesMsg::PANEL_CURRENTS_AVERAGE));
+  check_and_decode_key(
+      err, decode_key_value_double_array(&d.panel_currents_max, &d.num_lines, &value,
+                                         PowerSolarAveragesMsg::PANEL_CURRENTS_MAX));
+  check_and_decode_key(
+      err, decode_key_value_double_array(&d.panel_currents_min, &d.num_lines, &value,
+                                         PowerSolarAveragesMsg::PANEL_CURRENTS_MIN));
+  check_and_decode_key(
+      err, decode_key_value_double_array(&d.panel_currents_stdev, &d.num_lines, &value,
+                                         PowerSolarAveragesMsg::PANEL_CURRENTS_STDEV));
+
+  if (check_acceptable_decode_errors(err)) {
+    err = decoder_message_leave(&value, &map);
+  }
+
+  return err;
+}

--- a/power_solar_averages_msg.cpp
+++ b/power_solar_averages_msg.cpp
@@ -210,9 +210,18 @@ static inline void freePointer(double **pointer) {
  where array pointers are already NULL (e.g., freshly initialized or already freed).
 
  **MEMORY FREED**: The following array fields are deallocated:
- - panel_temparatures
- - panel_voltages
- - panel_currents
+ - panel_temparatures_average
+ - panel_temparatures_max
+ - panel_temparatures_min
+ - panel_temparatures_stdev
+ - panel_voltages_average
+ - panel_voltages_max
+ - panel_voltages_min
+ - panel_voltages_stdev
+ - panel_currents_average
+ - panel_currents_max
+ - panel_currents_min
+ - panel_currents_stdev
 
  @param d Reference to Data structure containing arrays to free. After this call,
           all array pointers will be set to NULL.

--- a/power_solar_averages_msg.cpp
+++ b/power_solar_averages_msg.cpp
@@ -95,7 +95,7 @@ CborError PowerSolarAveragesMsg::encode(Data &d, uint8_t *cbor_buffer, size_t si
  array will be skipped during decoding.
 
  **CALLER RESPONSIBILITY**: The caller is responsible for freeing all allocated array
- memory when no longer needed using bm_free().
+ memory when no longer needed using bm_free() or the provided PowerSolarAveragesMsg::free.
 
  @param d Reference to Data structure to populate. Array pointers must be NULL.
  @param cbor_buffer Pointer to the CBOR-encoded message buffer

--- a/power_solar_averages_msg.cpp
+++ b/power_solar_averages_msg.cpp
@@ -21,7 +21,11 @@ CborError PowerSolarAveragesMsg::encode(Data &d, uint8_t *cbor_buffer, size_t si
       return err;
     }
   }
-
+  check_and_encode_key(err,
+                       encode_key_value_uint8(&map_encoder, PowerReadingMsg::POWER_READING_TYPE,
+                                              d.power_reading_type));
+  check_and_encode_key(err,
+                       encode_key_value_uint8(&map_encoder, PowerReadingMsg::STATUS, d.status));
   check_and_encode_key(err, encode_key_value_uint32(&map_encoder,
                                                     PowerSolarAveragesMsg::NUM_SAMPLES,
                                                     d.num_samples));
@@ -118,7 +122,9 @@ CborError PowerSolarAveragesMsg::decode(Data &d, const uint8_t *cbor_buffer, siz
   if (err != CborNoError) {
     return err;
   }
-
+  check_and_decode_key(err, decode_key_value_uint8((uint8_t *)&d.power_reading_type, &value,
+                                                   PowerReadingMsg::POWER_READING_TYPE));
+  check_and_decode_key(err, decode_key_value_uint8(&d.status, &value, PowerReadingMsg::STATUS));
   check_and_decode_key(err, decode_key_value_uint32(&d.num_samples, &value,
                                                     PowerSolarAveragesMsg::NUM_SAMPLES));
   check_and_decode_key(
@@ -168,4 +174,61 @@ CborError PowerSolarAveragesMsg::decode(Data &d, const uint8_t *cbor_buffer, siz
   }
 
   return err;
+}
+
+/*!
+ @brief Helper function to safely free a double pointer and set it to NULL
+
+ @details Checks if the pointer is non-NULL before freeing, then sets it to NULL
+ to prevent double-free errors. Uses platform-appropriate free function.
+
+ @param pointer Pointer to a double pointer to free
+ */
+static inline void freePointer(double **pointer) {
+  if (*pointer) {
+#ifndef CI_TEST
+    bm_free(*pointer);
+#else
+    free(*pointer);
+#endif
+    *pointer = NULL;
+  }
+}
+
+/*!
+ @brief Frees all dynamically allocated memory in a PowerSolarReadingMsg Data structure
+
+ @details This function safely deallocates all array fields in the Data structure that
+ were allocated during decode operations. Each pointer is checked for NULL before
+ freeing, and all pointers are set to NULL after deallocation to prevent double-free
+ errors.
+
+ **SAFE TO CALL MULTIPLE TIMES**: This function can be called multiple times on the
+ same Data structure without causing crashes or undefined behavior.
+
+ **SAFE WITH UNINITIALIZED DATA**: This function can be safely called on Data structures
+ where array pointers are already NULL (e.g., freshly initialized or already freed).
+
+ **MEMORY FREED**: The following array fields are deallocated:
+ - panel_temparatures
+ - panel_voltages
+ - panel_currents
+
+ @param d Reference to Data structure containing arrays to free. After this call,
+          all array pointers will be set to NULL.
+ */
+void PowerSolarAveragesMsg::free(Data &d) {
+  freePointer(&d.panel_temperatures_average);
+  freePointer(&d.panel_temperatures_max);
+  freePointer(&d.panel_temperatures_min);
+  freePointer(&d.panel_temperatures_stdev);
+  freePointer(&d.panel_voltages_average);
+  freePointer(&d.panel_voltages_max);
+  freePointer(&d.panel_voltages_min);
+  freePointer(&d.panel_voltages_stdev);
+  freePointer(&d.panel_currents_average);
+  freePointer(&d.panel_currents_max);
+  freePointer(&d.panel_currents_min);
+  freePointer(&d.panel_currents_stdev);
+  return;
 }

--- a/power_solar_averages_msg.cpp
+++ b/power_solar_averages_msg.cpp
@@ -196,7 +196,7 @@ static inline void freePointer(double **pointer) {
 }
 
 /*!
- @brief Frees all dynamically allocated memory in a PowerSolarReadingMsg Data structure
+ @brief Frees all dynamically allocated memory in a PowerSolarAveragesMsg Data structure
 
  @details This function safely deallocates all array fields in the Data structure that
  were allocated during decode operations. Each pointer is checked for NULL before

--- a/power_solar_averages_msg.h
+++ b/power_solar_averages_msg.h
@@ -1,0 +1,48 @@
+#pragma once
+#include "cbor.h"
+#include "sensor_header_msg.h"
+
+namespace PowerSolarAveragesMsg {
+
+constexpr uint32_t VERSION = 1;
+constexpr size_t NUM_FIELDS = 14 + SensorHeaderMsg::NUM_FIELDS;
+static constexpr char NUM_SAMPLES[] = "num_samples";
+static constexpr char AVERAGING_WINDOW_LENGTH_S[] = "averaging_window_length_s";
+static constexpr char PANEL_TEMPERATURES_AVERAGE[] = "panel_temperatures_average";
+static constexpr char PANEL_TEMPERATURES_MAX[] = "panel_temperatures_max";
+static constexpr char PANEL_TEMPERATURES_MIN[] = "panel_temperatures_min";
+static constexpr char PANEL_TEMPERATURES_STDEV[] = "panel_temperatures_stdev";
+static constexpr char PANEL_VOLTAGES_AVERAGE[] = "panel_voltages_average";
+static constexpr char PANEL_VOLTAGES_MAX[] = "panel_voltages_max";
+static constexpr char PANEL_VOLTAGES_MIN[] = "panel_voltages_min";
+static constexpr char PANEL_VOLTAGES_STDEV[] = "panel_voltages_stdev";
+static constexpr char PANEL_CURRENTS_AVERAGE[] = "panel_currents_average";
+static constexpr char PANEL_CURRENTS_MAX[] = "panel_currents_max";
+static constexpr char PANEL_CURRENTS_MIN[] = "panel_currents_min";
+static constexpr char PANEL_CURRENTS_STDEV[] = "panel_currents_stdev";
+
+struct Data {
+  SensorHeaderMsg::Data header;
+  uint32_t num_samples;
+  double averaging_window_length_s;
+  uint8_t num_temp_sensors; // Not sent in cbor
+  uint8_t num_lines;  // Not sent in cbor
+  double *panel_temperatures_average;
+  double *panel_temperatures_max;
+  double *panel_temperatures_min;
+  double *panel_temperatures_stdev;
+  double *panel_voltages_average;
+  double *panel_voltages_max;
+  double *panel_voltages_min;
+  double *panel_voltages_stdev;
+  double *panel_currents_average;
+  double *panel_currents_max;
+  double *panel_currents_min;
+  double *panel_currents_stdev;
+};
+
+CborError encode(Data &d, uint8_t *cbor_buffer, size_t size, size_t *encoded_len);
+
+CborError decode(Data &d, const uint8_t *cbor_buffer, size_t size);
+
+} // namespace PowerSolarAveragesMsg

--- a/power_solar_averages_msg.h
+++ b/power_solar_averages_msg.h
@@ -1,11 +1,12 @@
 #pragma once
 #include "cbor.h"
+#include "power_reading_msg.h"
 #include "sensor_header_msg.h"
 
 namespace PowerSolarAveragesMsg {
 
 constexpr uint32_t VERSION = 1;
-constexpr size_t NUM_FIELDS = 14 + SensorHeaderMsg::NUM_FIELDS;
+constexpr size_t NUM_FIELDS = 16 + SensorHeaderMsg::NUM_FIELDS;
 static constexpr char NUM_SAMPLES[] = "num_samples";
 static constexpr char AVERAGING_WINDOW_LENGTH_S[] = "averaging_window_length_s";
 static constexpr char PANEL_TEMPERATURES_AVERAGE[] = "panel_temperatures_average";
@@ -23,6 +24,8 @@ static constexpr char PANEL_CURRENTS_STDEV[] = "panel_currents_stdev";
 
 struct Data {
   SensorHeaderMsg::Data header;
+  PowerReadingMsg::PowerReadingType_t power_reading_type;
+  uint8_t status;
   uint32_t num_samples;
   double averaging_window_length_s;
   uint8_t num_temp_sensors; // Not sent in cbor
@@ -44,5 +47,7 @@ struct Data {
 CborError encode(Data &d, uint8_t *cbor_buffer, size_t size, size_t *encoded_len);
 
 CborError decode(Data &d, const uint8_t *cbor_buffer, size_t size);
+
+void free(Data &d);
 
 } // namespace PowerSolarAveragesMsg

--- a/power_solar_reading_msg.cpp
+++ b/power_solar_reading_msg.cpp
@@ -31,10 +31,6 @@ CborError PowerSolarReadingMsg::encode(Data &d, uint8_t *cbor_buffer, size_t siz
       err, encode_key_value_double(&map_encoder, PowerReadingMsg::VOLTAGE_V, d.voltage_v));
   check_and_encode_key(
       err, encode_key_value_double(&map_encoder, PowerReadingMsg::CURRENT_A, d.current_a));
-
-  check_and_encode_key(err,
-                       encode_key_value_double(&map_encoder, PowerSolarReadingMsg::MPP_POSITION,
-                                               d.mpp_position));
   check_and_encode_key(
       err, encode_key_value_double_array(&map_encoder, PowerSolarReadingMsg::PANEL_TEMPERATURES,
                                          d.panel_temperatures, d.num_temp_sensors));
@@ -105,8 +101,6 @@ CborError PowerSolarReadingMsg::decode(Data &d, const uint8_t *cbor_buffer, size
       err, decode_key_value_double(&d.voltage_v, &value, PowerReadingMsg::VOLTAGE_V));
   check_and_decode_key(
       err, decode_key_value_double(&d.current_a, &value, PowerReadingMsg::CURRENT_A));
-  check_and_decode_key(err, decode_key_value_double(&d.mpp_position, &value,
-                                                    PowerSolarReadingMsg::MPP_POSITION));
   // decode the arrays
   check_and_decode_key(
       err, decode_key_value_double_array(&d.panel_temperatures, &d.num_temp_sensors, &value,

--- a/power_solar_reading_msg.cpp
+++ b/power_solar_reading_msg.cpp
@@ -124,3 +124,51 @@ CborError PowerSolarReadingMsg::decode(Data &d, const uint8_t *cbor_buffer, size
 
   return err;
 }
+
+/*!
+ @brief Helper function to safely free a double pointer and set it to NULL
+
+ @details Checks if the pointer is non-NULL before freeing, then sets it to NULL
+ to prevent double-free errors. Uses platform-appropriate free function.
+
+ @param pointer Pointer to a double pointer to free
+ */
+static inline void freePointer(double **pointer) {
+  if (*pointer) {
+#ifndef CI_TEST
+    bm_free(*pointer);
+#else
+    free(*pointer);
+#endif
+    *pointer = NULL;
+  }
+}
+
+/*!
+ @brief Frees all dynamically allocated memory in a PowerSolarReadingMsg Data structure
+
+ @details This function safely deallocates all array fields in the Data structure that
+ were allocated during decode operations. Each pointer is checked for NULL before
+ freeing, and all pointers are set to NULL after deallocation to prevent double-free
+ errors.
+
+ **SAFE TO CALL MULTIPLE TIMES**: This function can be called multiple times on the
+ same Data structure without causing crashes or undefined behavior.
+
+ **SAFE WITH UNINITIALIZED DATA**: This function can be safely called on Data structures
+ where array pointers are already NULL (e.g., freshly initialized or already freed).
+
+ **MEMORY FREED**: The following array fields are deallocated:
+ - panel_temparatures
+ - panel_voltages
+ - panel_currents
+
+ @param d Reference to Data structure containing arrays to free. After this call,
+          all array pointers will be set to NULL.
+ */
+void PowerSolarReadingMsg::free(Data &d) {
+  freePointer(&d.panel_temperatures);
+  freePointer(&d.panel_voltages);
+  freePointer(&d.panel_currents);
+  return;
+}

--- a/power_solar_reading_msg.cpp
+++ b/power_solar_reading_msg.cpp
@@ -30,7 +30,7 @@ CborError PowerSolarReadingMsg::encode(Data &d, uint8_t *cbor_buffer, size_t siz
   check_and_encode_key(
       err, encode_key_value_double(&map_encoder, PowerReadingMsg::VOLTAGE_V, d.voltage_v));
   check_and_encode_key(
-      err, encode_key_value_double(&map_encoder, PowerReadingMsg::current_a, d.current_a));
+      err, encode_key_value_double(&map_encoder, PowerReadingMsg::CURRENT_A, d.current_a));
 
   check_and_encode_key(err,
                        encode_key_value_double(&map_encoder, PowerSolarReadingMsg::MPP_POSITION,
@@ -107,7 +107,7 @@ CborError PowerSolarReadingMsg::decode(Data &d, const uint8_t *cbor_buffer, size
   check_and_decode_key(
       err, decode_key_value_double(&d.voltage_v, &value, PowerReadingMsg::VOLTAGE_V));
   check_and_decode_key(
-      err, decode_key_value_double(&d.current_a, &value, PowerReadingMsg::current_a));
+      err, decode_key_value_double(&d.current_a, &value, PowerReadingMsg::CURRENT_A));
   check_and_decode_key(err, decode_key_value_double(&d.mpp_position, &value,
                                                     PowerSolarReadingMsg::MPP_POSITION));
   check_and_decode_key(

--- a/power_solar_reading_msg.cpp
+++ b/power_solar_reading_msg.cpp
@@ -36,17 +36,14 @@ CborError PowerSolarReadingMsg::encode(Data &d, uint8_t *cbor_buffer, size_t siz
                        encode_key_value_double(&map_encoder, PowerSolarReadingMsg::MPP_POSITION,
                                                d.mpp_position));
   check_and_encode_key(
-      err, encode_key_value_uint8(&map_encoder, PowerSolarReadingMsg::NUM_PANLES, d.num_panels));
-
-  check_and_encode_key(
       err, encode_key_value_double_array(&map_encoder, PowerSolarReadingMsg::PANEL_TEMPERATURES,
-                                         d.panel_temperatures, d.num_panels));
+                                         d.panel_temperatures, d.num_temp_sensors));
   check_and_encode_key(err, encode_key_value_double_array(&map_encoder,
                                                           PowerSolarReadingMsg::PANEL_VOLTAGES,
-                                                          d.panel_voltages, d.num_panels));
+                                                          d.panel_voltages, d.num_lines));
   check_and_encode_key(err, encode_key_value_double_array(&map_encoder,
                                                           PowerSolarReadingMsg::PANEL_CURRENTS,
-                                                          d.panel_currents, d.num_panels));
+                                                          d.panel_currents, d.num_lines));
 
   if (check_acceptable_encode_errors(err)) {
     err = encoder_message_finish(&encoder, &map_encoder);
@@ -110,18 +107,15 @@ CborError PowerSolarReadingMsg::decode(Data &d, const uint8_t *cbor_buffer, size
       err, decode_key_value_double(&d.current_a, &value, PowerReadingMsg::CURRENT_A));
   check_and_decode_key(err, decode_key_value_double(&d.mpp_position, &value,
                                                     PowerSolarReadingMsg::MPP_POSITION));
-  check_and_decode_key(
-      err, decode_key_value_uint8(&d.num_panels, &value, PowerSolarReadingMsg::NUM_PANLES));
-
   // decode the arrays
   check_and_decode_key(
-      err, decode_key_value_double_array(&d.panel_temperatures, d.num_panels, &value,
+      err, decode_key_value_double_array(&d.panel_temperatures, &d.num_temp_sensors, &value,
                                          PowerSolarReadingMsg::PANEL_TEMPERATURES));
   check_and_decode_key(err,
-                       decode_key_value_double_array(&d.panel_voltages, d.num_panels, &value,
+                       decode_key_value_double_array(&d.panel_voltages, &d.num_lines, &value,
                                                      PowerSolarReadingMsg::PANEL_VOLTAGES));
   check_and_decode_key(err,
-                       decode_key_value_double_array(&d.panel_currents, d.num_panels, &value,
+                       decode_key_value_double_array(&d.panel_currents, &d.num_lines, &value,
                                                      PowerSolarReadingMsg::PANEL_CURRENTS));
 
   if (check_acceptable_decode_errors(err)) {

--- a/power_solar_reading_msg.cpp
+++ b/power_solar_reading_msg.cpp
@@ -1,0 +1,132 @@
+#include "power_solar_reading_msg.h"
+#include "bm_config.h"
+#include "bm_messages_helper.h"
+#ifndef CI_TEST
+#include "bm_os.h"
+#endif
+
+CborError PowerSolarReadingMsg::encode(Data &d, uint8_t *cbor_buffer, size_t size,
+                                       size_t *encoded_len) {
+  CborError err;
+  CborEncoder encoder, map_encoder;
+
+  err = encoder_message_create(&encoder, &map_encoder, cbor_buffer, size,
+                               PowerSolarReadingMsg::NUM_FIELDS);
+
+  // sensor_header_msg
+  err = SensorHeaderMsg::encode(map_encoder, d.header);
+  if (err != CborNoError) {
+    bm_debug("SensorHeaderMsg::encode failed: %d\n", err);
+    if (err != CborErrorOutOfMemory) {
+      return err;
+    }
+  }
+
+  check_and_encode_key(err,
+                       encode_key_value_uint8(&map_encoder, PowerReadingMsg::POWER_READING_TYPE,
+                                              d.power_reading_type));
+  check_and_encode_key(err,
+                       encode_key_value_uint8(&map_encoder, PowerReadingMsg::STATUS, d.status));
+  check_and_encode_key(
+      err, encode_key_value_double(&map_encoder, PowerReadingMsg::VOLTAGE_V, d.voltage_v));
+  check_and_encode_key(
+      err, encode_key_value_double(&map_encoder, PowerReadingMsg::current_a, d.current_a));
+
+  check_and_encode_key(err,
+                       encode_key_value_double(&map_encoder, PowerSolarReadingMsg::MPP_POSITION,
+                                               d.mpp_position));
+  check_and_encode_key(
+      err, encode_key_value_uint8(&map_encoder, PowerSolarReadingMsg::NUM_PANLES, d.num_panels));
+
+  check_and_encode_key(
+      err, encode_key_value_double_array(&map_encoder, PowerSolarReadingMsg::PANEL_TEMPERATURES,
+                                         d.panel_temperatures, d.num_panels));
+  check_and_encode_key(err, encode_key_value_double_array(&map_encoder,
+                                                          PowerSolarReadingMsg::PANEL_VOLTAGES,
+                                                          d.panel_voltages, d.num_panels));
+  check_and_encode_key(err, encode_key_value_double_array(&map_encoder,
+                                                          PowerSolarReadingMsg::PANEL_CURRENTS,
+                                                          d.panel_currents, d.num_panels));
+
+  if (check_acceptable_encode_errors(err)) {
+    err = encoder_message_finish(&encoder, &map_encoder);
+    *encoded_len = cbor_encoder_get_buffer_size(&encoder, cbor_buffer);
+  }
+
+  encoder_message_check_memory(&encoder, err);
+
+  return err;
+}
+
+/*!
+ @brief Decodes a PowerSolarReadingMsg from a CBOR buffer
+
+ @details This function decodes a CBOR-encoded PowerSolarReadingMsg and populates
+ the provided Data structure. It decodes the sensor header, power reading, and
+ dynamically sized arrays for solar panel measurements.
+
+ **MEMORY ALLOCATION**: This function allocates memory for all array fields in the
+ Data structure using bm_malloc().
+
+ **REQUIREMENTS**: All array pointer fields in the Data structure MUST be initialized
+ to NULL before calling this function. If an array pointer is already non-NULL, that
+ array will be skipped during decoding.
+
+ **CALLER RESPONSIBILITY**: The caller is responsible for freeing all allocated array
+ memory when no longer needed using bm_free().
+
+ @param d Reference to Data structure to populate. Array pointers must be NULL.
+ @param cbor_buffer Pointer to the CBOR-encoded message buffer
+ @param size Size of the CBOR buffer in bytes
+
+ @return CborError - CborNoError on success, or appropriate error code:
+         - CborErrorIllegalType if unexpected CBOR types are encountered
+         - CborErrorOutOfMemory if memory allocation fails
+         - Other CBOR errors from underlying decode operations
+ */
+CborError PowerSolarReadingMsg::decode(Data &d, const uint8_t *cbor_buffer, size_t size) {
+  CborParser parser;
+  CborValue map, value;
+  CborError err;
+
+  err = decoder_message_enter(&map, &value, &parser, (uint8_t *)cbor_buffer, size,
+                              PowerSolarReadingMsg::NUM_FIELDS);
+  if (err != CborNoError) {
+    return err;
+  }
+
+  // decode header
+  err = SensorHeaderMsg::decode(value, d.header);
+  if (err != CborNoError) {
+    return err;
+  }
+
+  check_and_decode_key(err, decode_key_value_uint8((uint8_t *)&d.power_reading_type, &value,
+                                                   PowerReadingMsg::POWER_READING_TYPE));
+  check_and_decode_key(err, decode_key_value_uint8(&d.status, &value, PowerReadingMsg::STATUS));
+  check_and_decode_key(
+      err, decode_key_value_double(&d.voltage_v, &value, PowerReadingMsg::VOLTAGE_V));
+  check_and_decode_key(
+      err, decode_key_value_double(&d.current_a, &value, PowerReadingMsg::current_a));
+  check_and_decode_key(err, decode_key_value_double(&d.mpp_position, &value,
+                                                    PowerSolarReadingMsg::MPP_POSITION));
+  check_and_decode_key(
+      err, decode_key_value_uint8(&d.num_panels, &value, PowerSolarReadingMsg::NUM_PANLES));
+
+  // decode the arrays
+  check_and_decode_key(
+      err, decode_key_value_double_array(&d.panel_temperatures, d.num_panels, &value,
+                                         PowerSolarReadingMsg::PANEL_TEMPERATURES));
+  check_and_decode_key(err,
+                       decode_key_value_double_array(&d.panel_voltages, d.num_panels, &value,
+                                                     PowerSolarReadingMsg::PANEL_VOLTAGES));
+  check_and_decode_key(err,
+                       decode_key_value_double_array(&d.panel_currents, d.num_panels, &value,
+                                                     PowerSolarReadingMsg::PANEL_CURRENTS));
+
+  if (check_acceptable_decode_errors(err)) {
+    err = decoder_message_leave(&value, &map);
+  }
+
+  return err;
+}

--- a/power_solar_reading_msg.cpp
+++ b/power_solar_reading_msg.cpp
@@ -66,7 +66,7 @@ CborError PowerSolarReadingMsg::encode(Data &d, uint8_t *cbor_buffer, size_t siz
  array will be skipped during decoding.
 
  **CALLER RESPONSIBILITY**: The caller is responsible for freeing all allocated array
- memory when no longer needed using bm_free().
+ memory when no longer needed using bm_free() or the provided PowerSolarReadingMsg::free.
 
  @param d Reference to Data structure to populate. Array pointers must be NULL.
  @param cbor_buffer Pointer to the CBOR-encoded message buffer

--- a/power_solar_reading_msg.h
+++ b/power_solar_reading_msg.h
@@ -1,0 +1,37 @@
+#pragma once
+#include "cbor.h"
+#include "power_reading_msg.h"
+#include "sensor_header_msg.h"
+
+namespace PowerSolarReadingMsg {
+
+constexpr uint32_t VERSION = 1;
+constexpr size_t NUM_FIELDS = 9 + SensorHeaderMsg::NUM_FIELDS;
+static constexpr char MPP_POSITION[] = "mpp_position";
+// static constexpr char NUM_TEMP_SENSORS[] = "num_temp_sensors";
+// static constexpr char NUM_LINES[] = "num_lines";
+static constexpr char PANEL_TEMPERATURES[] = "panel_temperatures";
+static constexpr char PANEL_VOLTAGES[] = "panel_voltages";
+static constexpr char PANEL_CURRENTS[] = "panel_currents";
+static constexpr char NUM_PANLES[] = "num_panels";
+
+struct Data {
+  SensorHeaderMsg::Data header;
+  PowerReadingMsg::PowerReadingType_t power_reading_type;
+  uint8_t status;
+  double voltage_v;
+  double current_a;
+  double mpp_position;
+  // uint8_t num_temp_sensors;
+  // uint8_t num_lines;
+  uint8_t num_panels;
+  double *panel_temperatures;
+  double *panel_voltages;
+  double *panel_currents;
+};
+
+CborError encode(Data &d, uint8_t *cbor_buffer, size_t size, size_t *encoded_len);
+
+CborError decode(Data &d, const uint8_t *cbor_buffer, size_t size);
+
+} // namespace PowerSolarReadingMsg

--- a/power_solar_reading_msg.h
+++ b/power_solar_reading_msg.h
@@ -6,14 +6,11 @@
 namespace PowerSolarReadingMsg {
 
 constexpr uint32_t VERSION = 1;
-constexpr size_t NUM_FIELDS = 9 + SensorHeaderMsg::NUM_FIELDS;
+constexpr size_t NUM_FIELDS = 8 + SensorHeaderMsg::NUM_FIELDS;
 static constexpr char MPP_POSITION[] = "mpp_position";
-// static constexpr char NUM_TEMP_SENSORS[] = "num_temp_sensors";
-// static constexpr char NUM_LINES[] = "num_lines";
 static constexpr char PANEL_TEMPERATURES[] = "panel_temperatures";
 static constexpr char PANEL_VOLTAGES[] = "panel_voltages";
 static constexpr char PANEL_CURRENTS[] = "panel_currents";
-static constexpr char NUM_PANLES[] = "num_panels";
 
 struct Data {
   SensorHeaderMsg::Data header;
@@ -22,10 +19,9 @@ struct Data {
   double voltage_v;
   double current_a;
   double mpp_position;
-  // uint8_t num_temp_sensors;
-  // uint8_t num_lines;
-  uint8_t num_panels;
+  uint8_t num_temp_sensors;
   double *panel_temperatures;
+  uint8_t num_lines;
   double *panel_voltages;
   double *panel_currents;
 };

--- a/power_solar_reading_msg.h
+++ b/power_solar_reading_msg.h
@@ -30,4 +30,6 @@ CborError encode(Data &d, uint8_t *cbor_buffer, size_t size, size_t *encoded_len
 
 CborError decode(Data &d, const uint8_t *cbor_buffer, size_t size);
 
+void free(Data &d);
+
 } // namespace PowerSolarReadingMsg

--- a/power_solar_reading_msg.h
+++ b/power_solar_reading_msg.h
@@ -6,8 +6,7 @@
 namespace PowerSolarReadingMsg {
 
 constexpr uint32_t VERSION = 1;
-constexpr size_t NUM_FIELDS = 8 + SensorHeaderMsg::NUM_FIELDS;
-static constexpr char MPP_POSITION[] = "mpp_position";
+constexpr size_t NUM_FIELDS = 7 + SensorHeaderMsg::NUM_FIELDS;
 static constexpr char PANEL_TEMPERATURES[] = "panel_temperatures";
 static constexpr char PANEL_VOLTAGES[] = "panel_voltages";
 static constexpr char PANEL_CURRENTS[] = "panel_currents";
@@ -18,7 +17,6 @@ struct Data {
   uint8_t status;
   double voltage_v;
   double current_a;
-  double mpp_position;
   uint8_t num_temp_sensors;
   double *panel_temperatures;
   uint8_t num_lines;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -65,6 +65,7 @@ set(BM_COMMON_MESSAGES_SRCS
     ${SRC_DIR}/power_battery_averages_msg.cpp
     ${SRC_DIR}/power_reading_msg.cpp
     ${SRC_DIR}/power_reading_averages_msg.cpp
+    ${SRC_DIR}/power_solar_reading_msg.cpp
     ${SRC_DIR}/aanderaa_conductivity_msg.cpp
     ${SRC_DIR}/aanderaa_current_meter_msg.cpp
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -66,6 +66,7 @@ set(BM_COMMON_MESSAGES_SRCS
     ${SRC_DIR}/power_reading_msg.cpp
     ${SRC_DIR}/power_reading_averages_msg.cpp
     ${SRC_DIR}/power_solar_reading_msg.cpp
+    ${SRC_DIR}/power_solar_averages_msg.cpp
     ${SRC_DIR}/aanderaa_conductivity_msg.cpp
     ${SRC_DIR}/aanderaa_current_meter_msg.cpp
 

--- a/test/bm_common_messages_tests_ut.cpp
+++ b/test/bm_common_messages_tests_ut.cpp
@@ -982,7 +982,7 @@ TEST_F(BmCommonTest, PowerSolarReadingTest) {
   uint8_t cbor_buffer[1024];
   size_t len = 0;
   PowerSolarReadingMsg::encode(d, cbor_buffer, sizeof(cbor_buffer), &len);
-  EXPECT_EQ(len, 257);
+  EXPECT_EQ(len, 235);
 
   PowerSolarReadingMsg::Data decode = {};
   err = PowerSolarReadingMsg::decode(decode, cbor_buffer, len);
@@ -1034,7 +1034,7 @@ TEST_F(BmCommonTest, PowerSolarReadingTest) {
   uint8_t cbor_buffer2[1024];
   size_t len2 = 0;
   PowerSolarReadingMsg::encode(d2, cbor_buffer2, sizeof(cbor_buffer2), &len2);
-  EXPECT_EQ(len2, 230);
+  EXPECT_EQ(len2, 208);
 
   PowerSolarReadingMsg::Data decode2 = {};
   err = PowerSolarReadingMsg::decode(decode2, cbor_buffer2, len2);
@@ -1077,7 +1077,7 @@ TEST_F(BmCommonTest, PowerSolarReadingTest) {
   uint8_t cbor_buffer3[1024];
   size_t len3 = 0;
   PowerSolarReadingMsg::encode(d3, cbor_buffer3, sizeof(cbor_buffer3), &len3);
-  EXPECT_EQ(len3, 365);
+  EXPECT_EQ(len3, 343);
 
   PowerSolarReadingMsg::Data decode3 = {};
   err = PowerSolarReadingMsg::decode(decode3, cbor_buffer3, len3);
@@ -1133,7 +1133,7 @@ TEST_F(BmCommonTest, PowerSolarReadingTest) {
   uint8_t cbor_buffer4[1024];
   size_t len4 = 0;
   PowerSolarReadingMsg::encode(d4, cbor_buffer4, sizeof(cbor_buffer4), &len4);
-  EXPECT_EQ(len4, 347);
+  EXPECT_EQ(len4, 325);
 
   PowerSolarReadingMsg::Data decode4 = {};
   err = PowerSolarReadingMsg::decode(decode4, cbor_buffer4, len4);

--- a/test/bm_common_messages_tests_ut.cpp
+++ b/test/bm_common_messages_tests_ut.cpp
@@ -18,6 +18,8 @@
 #include "power_battery_msg.h"
 #include "power_reading_averages_msg.h"
 #include "power_reading_msg.h"
+#include "power_solar_reading_msg.h"
+#include "power_solar_reading_msg.h"
 #include "sensor_header_msg.h"
 #include "sys_info_svc_reply_msg.h"
 #include "gtest/gtest.h"
@@ -954,4 +956,159 @@ TEST_F(BmCommonTest, PowerBatteryAveragesTest) {
 
   PowerBatteryAveragesMsg::free(d2);
   PowerBatteryAveragesMsg::free(decode2);
+}
+
+TEST_F(BmCommonTest, PowerSolarReadingTest) {
+  CborError err = CborNoError;
+  // Test with num_panels == 1
+  PowerSolarReadingMsg::Data d;
+  d.header.version = PowerSolarReadingMsg::VERSION;
+  d.header.reading_time_utc_ms = 123456789;
+  d.header.reading_uptime_millis = 987654321;
+  d.header.sensor_reading_time_ms = 0xdeadc0de;
+  d.power_reading_type = PowerReadingMsg::SOURCE;
+  d.status = PowerReadingMsg::OKAY;
+  d.voltage_v = 24.5;
+  d.current_a = 8.3;
+  d.mpp_position = 95.5;
+  d.num_panels = 1;
+  d.panel_temperatures = (double *)malloc(sizeof(double));
+  d.panel_temperatures[0] = 45.2;
+  d.panel_voltages = (double *)malloc(sizeof(double));
+  d.panel_voltages[0] = 24.5;
+  d.panel_currents = (double *)malloc(sizeof(double));
+  d.panel_currents[0] = 8.3;
+
+  uint8_t cbor_buffer[1024];
+  size_t len = 0;
+  PowerSolarReadingMsg::encode(d, cbor_buffer, sizeof(cbor_buffer), &len);
+  EXPECT_EQ(len, 269);
+
+  PowerSolarReadingMsg::Data decode = {};
+  err = PowerSolarReadingMsg::decode(decode, cbor_buffer, len);
+  EXPECT_EQ(err, CborNoError);
+  EXPECT_EQ(decode.header.version, d.header.version);
+  EXPECT_EQ(decode.header.reading_time_utc_ms, d.header.reading_time_utc_ms);
+  EXPECT_EQ(decode.header.reading_uptime_millis, d.header.reading_uptime_millis);
+  EXPECT_EQ(decode.header.sensor_reading_time_ms, d.header.sensor_reading_time_ms);
+  EXPECT_EQ(decode.power_reading_type, d.power_reading_type);
+  EXPECT_EQ(decode.status, d.status);
+  EXPECT_EQ(decode.voltage_v, d.voltage_v);
+  EXPECT_EQ(decode.current_a, d.current_a);
+  EXPECT_EQ(decode.mpp_position, d.mpp_position);
+  EXPECT_EQ(decode.num_panels, d.num_panels);
+  EXPECT_EQ(decode.panel_temperatures[0], d.panel_temperatures[0]);
+  EXPECT_EQ(decode.panel_voltages[0], d.panel_voltages[0]);
+  EXPECT_EQ(decode.panel_currents[0], d.panel_currents[0]);
+
+  free(d.panel_temperatures);
+  free(d.panel_voltages);
+  free(d.panel_currents);
+  free(decode.panel_temperatures);
+  free(decode.panel_voltages);
+  free(decode.panel_currents);
+
+  // Test with num_panels == 0
+  PowerSolarReadingMsg::Data d2 = {};
+  d2.header.version = PowerSolarReadingMsg::VERSION;
+  d2.header.reading_time_utc_ms = 123456789;
+  d2.header.reading_uptime_millis = 987654321;
+  d2.header.sensor_reading_time_ms = 0xdeadc0de;
+  d2.power_reading_type = PowerReadingMsg::SOURCE;
+  d2.status = PowerReadingMsg::OKAY;
+  d2.voltage_v = 24.5;
+  d2.current_a = 8.3;
+  d2.mpp_position = 95.5;
+  d2.num_panels = 0;
+
+  uint8_t cbor_buffer2[1024];
+  size_t len2 = 0;
+  PowerSolarReadingMsg::encode(d2, cbor_buffer2, sizeof(cbor_buffer2), &len2);
+  EXPECT_EQ(len2, 242);
+
+  PowerSolarReadingMsg::Data decode2 = {};
+  err = PowerSolarReadingMsg::decode(decode2, cbor_buffer2, len2);
+  EXPECT_EQ(err, CborNoError);
+  EXPECT_EQ(decode2.header.version, d2.header.version);
+  EXPECT_EQ(decode2.header.reading_time_utc_ms, d2.header.reading_time_utc_ms);
+  EXPECT_EQ(decode2.header.reading_uptime_millis, d2.header.reading_uptime_millis);
+  EXPECT_EQ(decode2.header.sensor_reading_time_ms, d2.header.sensor_reading_time_ms);
+  EXPECT_EQ(decode2.power_reading_type, d2.power_reading_type);
+  EXPECT_EQ(decode2.status, d2.status);
+  EXPECT_EQ(decode2.voltage_v, d2.voltage_v);
+  EXPECT_EQ(decode2.current_a, d2.current_a);
+  EXPECT_EQ(decode2.mpp_position, d2.mpp_position);
+  EXPECT_EQ(decode2.num_panels, d2.num_panels);
+
+  // Test with num_panels == 5
+  PowerSolarReadingMsg::Data d3;
+  d3.header.version = PowerSolarReadingMsg::VERSION;
+  d3.header.reading_time_utc_ms = 123456789;
+  d3.header.reading_uptime_millis = 987654321;
+  d3.header.sensor_reading_time_ms = 0xdeadc0de;
+  d3.power_reading_type = PowerReadingMsg::SOURCE;
+  d3.status = PowerReadingMsg::OKAY;
+  d3.voltage_v = 120.0;
+  d3.current_a = 40.5;
+  d3.mpp_position = 98.3;
+  d3.num_panels = 5;
+  d3.panel_temperatures = (double *)malloc(sizeof(double) * d3.num_panels);
+  d3.panel_temperatures[0] = 45.2;
+  d3.panel_temperatures[1] = 46.1;
+  d3.panel_temperatures[2] = 44.8;
+  d3.panel_temperatures[3] = 47.3;
+  d3.panel_temperatures[4] = 45.9;
+  d3.panel_voltages = (double *)malloc(sizeof(double) * d3.num_panels);
+  d3.panel_voltages[0] = 24.1;
+  d3.panel_voltages[1] = 24.3;
+  d3.panel_voltages[2] = 23.9;
+  d3.panel_voltages[3] = 24.0;
+  d3.panel_voltages[4] = 24.2;
+  d3.panel_currents = (double *)malloc(sizeof(double) * d3.num_panels);
+  d3.panel_currents[0] = 8.1;
+  d3.panel_currents[1] = 8.2;
+  d3.panel_currents[2] = 8.0;
+  d3.panel_currents[3] = 8.15;
+  d3.panel_currents[4] = 8.05;
+
+  uint8_t cbor_buffer3[1024];
+  size_t len3 = 0;
+  PowerSolarReadingMsg::encode(d3, cbor_buffer3, sizeof(cbor_buffer3), &len3);
+  EXPECT_EQ(len3, 377);
+
+  PowerSolarReadingMsg::Data decode3 = {};
+  err = PowerSolarReadingMsg::decode(decode3, cbor_buffer3, len3);
+  EXPECT_EQ(err, CborNoError);
+  EXPECT_EQ(decode3.header.version, d3.header.version);
+  EXPECT_EQ(decode3.header.reading_time_utc_ms, d3.header.reading_time_utc_ms);
+  EXPECT_EQ(decode3.header.reading_uptime_millis, d3.header.reading_uptime_millis);
+  EXPECT_EQ(decode3.header.sensor_reading_time_ms, d3.header.sensor_reading_time_ms);
+  EXPECT_EQ(decode3.power_reading_type, d3.power_reading_type);
+  EXPECT_EQ(decode3.status, d3.status);
+  EXPECT_EQ(decode3.voltage_v, d3.voltage_v);
+  EXPECT_EQ(decode3.current_a, d3.current_a);
+  EXPECT_EQ(decode3.mpp_position, d3.mpp_position);
+  EXPECT_EQ(decode3.num_panels, d3.num_panels);
+  EXPECT_EQ(decode3.panel_temperatures[0], d3.panel_temperatures[0]);
+  EXPECT_EQ(decode3.panel_temperatures[1], d3.panel_temperatures[1]);
+  EXPECT_EQ(decode3.panel_temperatures[2], d3.panel_temperatures[2]);
+  EXPECT_EQ(decode3.panel_temperatures[3], d3.panel_temperatures[3]);
+  EXPECT_EQ(decode3.panel_temperatures[4], d3.panel_temperatures[4]);
+  EXPECT_EQ(decode3.panel_voltages[0], d3.panel_voltages[0]);
+  EXPECT_EQ(decode3.panel_voltages[1], d3.panel_voltages[1]);
+  EXPECT_EQ(decode3.panel_voltages[2], d3.panel_voltages[2]);
+  EXPECT_EQ(decode3.panel_voltages[3], d3.panel_voltages[3]);
+  EXPECT_EQ(decode3.panel_voltages[4], d3.panel_voltages[4]);
+  EXPECT_EQ(decode3.panel_currents[0], d3.panel_currents[0]);
+  EXPECT_EQ(decode3.panel_currents[1], d3.panel_currents[1]);
+  EXPECT_EQ(decode3.panel_currents[2], d3.panel_currents[2]);
+  EXPECT_EQ(decode3.panel_currents[3], d3.panel_currents[3]);
+  EXPECT_EQ(decode3.panel_currents[4], d3.panel_currents[4]);
+
+  free(d3.panel_temperatures);
+  free(d3.panel_voltages);
+  free(d3.panel_currents);
+  free(decode3.panel_temperatures);
+  free(decode3.panel_voltages);
+  free(decode3.panel_currents);
 }

--- a/test/bm_common_messages_tests_ut.cpp
+++ b/test/bm_common_messages_tests_ut.cpp
@@ -1053,28 +1053,18 @@ TEST_F(BmCommonTest, PowerSolarReadingTest) {
   d3.mpp_position = 98.3;
   d3.num_panels = 5;
   d3.panel_temperatures = (double *)malloc(sizeof(double) * d3.num_panels);
-  d3.panel_temperatures[0] = 45.2;
-  d3.panel_temperatures[1] = 46.1;
-  d3.panel_temperatures[2] = 44.8;
-  d3.panel_temperatures[3] = 47.3;
-  d3.panel_temperatures[4] = 45.9;
   d3.panel_voltages = (double *)malloc(sizeof(double) * d3.num_panels);
-  d3.panel_voltages[0] = 24.1;
-  d3.panel_voltages[1] = 24.3;
-  d3.panel_voltages[2] = 23.9;
-  d3.panel_voltages[3] = 24.0;
-  d3.panel_voltages[4] = 24.2;
   d3.panel_currents = (double *)malloc(sizeof(double) * d3.num_panels);
-  d3.panel_currents[0] = 8.1;
-  d3.panel_currents[1] = 8.2;
-  d3.panel_currents[2] = 8.0;
-  d3.panel_currents[3] = 8.15;
-  d3.panel_currents[4] = 8.05;
+  for (size_t i = 0; i < d3.num_panels; i++) {
+    d3.panel_temperatures[i] = 45.0 + i * 0.5;
+    d3.panel_voltages[i] = 24.0 + i * 0.1;
+    d3.panel_currents[i] = 8.0 + i * 0.05;
+  }
 
   uint8_t cbor_buffer3[1024];
   size_t len3 = 0;
   PowerSolarReadingMsg::encode(d3, cbor_buffer3, sizeof(cbor_buffer3), &len3);
-  EXPECT_EQ(len3, 377);
+  EXPECT_GT(len3, 0);
 
   PowerSolarReadingMsg::Data decode3 = {};
   err = PowerSolarReadingMsg::decode(decode3, cbor_buffer3, len3);
@@ -1089,21 +1079,11 @@ TEST_F(BmCommonTest, PowerSolarReadingTest) {
   EXPECT_EQ(decode3.current_a, d3.current_a);
   EXPECT_EQ(decode3.mpp_position, d3.mpp_position);
   EXPECT_EQ(decode3.num_panels, d3.num_panels);
-  EXPECT_EQ(decode3.panel_temperatures[0], d3.panel_temperatures[0]);
-  EXPECT_EQ(decode3.panel_temperatures[1], d3.panel_temperatures[1]);
-  EXPECT_EQ(decode3.panel_temperatures[2], d3.panel_temperatures[2]);
-  EXPECT_EQ(decode3.panel_temperatures[3], d3.panel_temperatures[3]);
-  EXPECT_EQ(decode3.panel_temperatures[4], d3.panel_temperatures[4]);
-  EXPECT_EQ(decode3.panel_voltages[0], d3.panel_voltages[0]);
-  EXPECT_EQ(decode3.panel_voltages[1], d3.panel_voltages[1]);
-  EXPECT_EQ(decode3.panel_voltages[2], d3.panel_voltages[2]);
-  EXPECT_EQ(decode3.panel_voltages[3], d3.panel_voltages[3]);
-  EXPECT_EQ(decode3.panel_voltages[4], d3.panel_voltages[4]);
-  EXPECT_EQ(decode3.panel_currents[0], d3.panel_currents[0]);
-  EXPECT_EQ(decode3.panel_currents[1], d3.panel_currents[1]);
-  EXPECT_EQ(decode3.panel_currents[2], d3.panel_currents[2]);
-  EXPECT_EQ(decode3.panel_currents[3], d3.panel_currents[3]);
-  EXPECT_EQ(decode3.panel_currents[4], d3.panel_currents[4]);
+  for (size_t i = 0; i < d3.num_panels; i++) {
+    EXPECT_EQ(decode3.panel_temperatures[i], d3.panel_temperatures[i]);
+    EXPECT_EQ(decode3.panel_voltages[i], d3.panel_voltages[i]);
+    EXPECT_EQ(decode3.panel_currents[i], d3.panel_currents[i]);
+  }
 
   free(d3.panel_temperatures);
   free(d3.panel_voltages);

--- a/test/bm_common_messages_tests_ut.cpp
+++ b/test/bm_common_messages_tests_ut.cpp
@@ -960,7 +960,7 @@ TEST_F(BmCommonTest, PowerBatteryAveragesTest) {
 
 TEST_F(BmCommonTest, PowerSolarReadingTest) {
   CborError err = CborNoError;
-  // Test with num_panels == 1
+  // Test with nun_temps_sensors and num_lines == 1
   PowerSolarReadingMsg::Data d;
   d.header.version = PowerSolarReadingMsg::VERSION;
   d.header.reading_time_utc_ms = 123456789;
@@ -971,7 +971,8 @@ TEST_F(BmCommonTest, PowerSolarReadingTest) {
   d.voltage_v = 24.5;
   d.current_a = 8.3;
   d.mpp_position = 95.5;
-  d.num_panels = 1;
+  d.num_temp_sensors = 1;
+  d.num_lines = 1;
   d.panel_temperatures = (double *)malloc(sizeof(double));
   d.panel_temperatures[0] = 45.2;
   d.panel_voltages = (double *)malloc(sizeof(double));
@@ -982,7 +983,7 @@ TEST_F(BmCommonTest, PowerSolarReadingTest) {
   uint8_t cbor_buffer[1024];
   size_t len = 0;
   PowerSolarReadingMsg::encode(d, cbor_buffer, sizeof(cbor_buffer), &len);
-  EXPECT_EQ(len, 269);
+  EXPECT_EQ(len, 257);
 
   PowerSolarReadingMsg::Data decode = {};
   err = PowerSolarReadingMsg::decode(decode, cbor_buffer, len);
@@ -996,7 +997,8 @@ TEST_F(BmCommonTest, PowerSolarReadingTest) {
   EXPECT_EQ(decode.voltage_v, d.voltage_v);
   EXPECT_EQ(decode.current_a, d.current_a);
   EXPECT_EQ(decode.mpp_position, d.mpp_position);
-  EXPECT_EQ(decode.num_panels, d.num_panels);
+  EXPECT_EQ(decode.num_temp_sensors, d.num_temp_sensors);
+  EXPECT_EQ(decode.num_lines, d.num_lines);
   EXPECT_EQ(decode.panel_temperatures[0], d.panel_temperatures[0]);
   EXPECT_EQ(decode.panel_voltages[0], d.panel_voltages[0]);
   EXPECT_EQ(decode.panel_currents[0], d.panel_currents[0]);
@@ -1008,7 +1010,7 @@ TEST_F(BmCommonTest, PowerSolarReadingTest) {
   free(decode.panel_voltages);
   free(decode.panel_currents);
 
-  // Test with num_panels == 0
+  // Test with num_temp_sensors and num_lines == 0
   PowerSolarReadingMsg::Data d2 = {};
   d2.header.version = PowerSolarReadingMsg::VERSION;
   d2.header.reading_time_utc_ms = 123456789;
@@ -1019,12 +1021,13 @@ TEST_F(BmCommonTest, PowerSolarReadingTest) {
   d2.voltage_v = 24.5;
   d2.current_a = 8.3;
   d2.mpp_position = 95.5;
-  d2.num_panels = 0;
+  d2.num_temp_sensors = 0;
+  d2.num_lines = 0;
 
   uint8_t cbor_buffer2[1024];
   size_t len2 = 0;
   PowerSolarReadingMsg::encode(d2, cbor_buffer2, sizeof(cbor_buffer2), &len2);
-  EXPECT_EQ(len2, 242);
+  EXPECT_EQ(len2, 230);
 
   PowerSolarReadingMsg::Data decode2 = {};
   err = PowerSolarReadingMsg::decode(decode2, cbor_buffer2, len2);
@@ -1038,9 +1041,10 @@ TEST_F(BmCommonTest, PowerSolarReadingTest) {
   EXPECT_EQ(decode2.voltage_v, d2.voltage_v);
   EXPECT_EQ(decode2.current_a, d2.current_a);
   EXPECT_EQ(decode2.mpp_position, d2.mpp_position);
-  EXPECT_EQ(decode2.num_panels, d2.num_panels);
+  EXPECT_EQ(decode2.num_temp_sensors, d2.num_temp_sensors);
+  EXPECT_EQ(decode2.num_lines, d2.num_lines);
 
-  // Test with num_panels == 5
+  // Test with num_temp_sensors and num_lines == 5
   PowerSolarReadingMsg::Data d3;
   d3.header.version = PowerSolarReadingMsg::VERSION;
   d3.header.reading_time_utc_ms = 123456789;
@@ -1051,11 +1055,12 @@ TEST_F(BmCommonTest, PowerSolarReadingTest) {
   d3.voltage_v = 120.0;
   d3.current_a = 40.5;
   d3.mpp_position = 98.3;
-  d3.num_panels = 5;
-  d3.panel_temperatures = (double *)malloc(sizeof(double) * d3.num_panels);
-  d3.panel_voltages = (double *)malloc(sizeof(double) * d3.num_panels);
-  d3.panel_currents = (double *)malloc(sizeof(double) * d3.num_panels);
-  for (size_t i = 0; i < d3.num_panels; i++) {
+  d3.num_temp_sensors = 5;
+  d3.num_lines = 5;
+  d3.panel_temperatures = (double *)malloc(sizeof(double) * d3.num_temp_sensors);
+  d3.panel_voltages = (double *)malloc(sizeof(double) * d3.num_lines);
+  d3.panel_currents = (double *)malloc(sizeof(double) * d3.num_lines);
+  for (size_t i = 0; i < d3.num_temp_sensors; i++) {
     d3.panel_temperatures[i] = 45.0 + i * 0.5;
     d3.panel_voltages[i] = 24.0 + i * 0.1;
     d3.panel_currents[i] = 8.0 + i * 0.05;
@@ -1064,7 +1069,7 @@ TEST_F(BmCommonTest, PowerSolarReadingTest) {
   uint8_t cbor_buffer3[1024];
   size_t len3 = 0;
   PowerSolarReadingMsg::encode(d3, cbor_buffer3, sizeof(cbor_buffer3), &len3);
-  EXPECT_GT(len3, 0);
+  EXPECT_EQ(len3, 365);
 
   PowerSolarReadingMsg::Data decode3 = {};
   err = PowerSolarReadingMsg::decode(decode3, cbor_buffer3, len3);
@@ -1078,8 +1083,9 @@ TEST_F(BmCommonTest, PowerSolarReadingTest) {
   EXPECT_EQ(decode3.voltage_v, d3.voltage_v);
   EXPECT_EQ(decode3.current_a, d3.current_a);
   EXPECT_EQ(decode3.mpp_position, d3.mpp_position);
-  EXPECT_EQ(decode3.num_panels, d3.num_panels);
-  for (size_t i = 0; i < d3.num_panels; i++) {
+  EXPECT_EQ(decode3.num_temp_sensors, d3.num_temp_sensors);
+  EXPECT_EQ(decode3.num_lines, d3.num_lines);
+  for (size_t i = 0; i < d3.num_temp_sensors; i++) {
     EXPECT_EQ(decode3.panel_temperatures[i], d3.panel_temperatures[i]);
     EXPECT_EQ(decode3.panel_voltages[i], d3.panel_voltages[i]);
     EXPECT_EQ(decode3.panel_currents[i], d3.panel_currents[i]);
@@ -1091,4 +1097,68 @@ TEST_F(BmCommonTest, PowerSolarReadingTest) {
   free(decode3.panel_temperatures);
   free(decode3.panel_voltages);
   free(decode3.panel_currents);
+
+  // Test with nun_temps_sensors == 1 and num_lines == 6
+  PowerSolarReadingMsg::Data d4;
+  d4.header.version = PowerSolarReadingMsg::VERSION;
+  d4.header.reading_time_utc_ms = 123456789;
+  d4.header.reading_uptime_millis = 987654321;
+  d4.header.sensor_reading_time_ms = 0xdeadc0de;
+  d4.power_reading_type = PowerReadingMsg::SOURCE;
+  d4.status = PowerReadingMsg::OKAY;
+  d4.voltage_v = 24.5;
+  d4.current_a = 8.3;
+  d4.mpp_position = 95.5;
+  d4.num_temp_sensors = 1;
+  d4.num_lines = 6;
+  d4.panel_temperatures = (double *)malloc(sizeof(double) * d4.num_temp_sensors);
+  d4.panel_temperatures[0] = 45.2;
+  d4.panel_voltages = (double *)malloc(sizeof(double) * d4.num_lines);
+  d4.panel_voltages[0] = 24.5;
+  d4.panel_voltages[1] = 23.68;
+  d4.panel_voltages[2] = 29.09;
+  d4.panel_voltages[3] = 22.01;
+  d4.panel_voltages[4] = 22.55;
+  d4.panel_voltages[5] = 23.13;
+  d4.panel_currents = (double *)malloc(sizeof(double)* d4.num_lines);
+  d4.panel_currents[0] = 8.3;
+  d4.panel_currents[1] = 6.34;
+  d4.panel_currents[2] = 7.49;
+  d4.panel_currents[3] = 8.64;
+  d4.panel_currents[4] = 9.03;
+  d4.panel_currents[5] = 8.52;
+
+  uint8_t cbor_buffer4[1024];
+  size_t len4 = 0;
+  PowerSolarReadingMsg::encode(d4, cbor_buffer4, sizeof(cbor_buffer4), &len4);
+  EXPECT_EQ(len4, 347);
+
+  PowerSolarReadingMsg::Data decode4 = {};
+  err = PowerSolarReadingMsg::decode(decode4, cbor_buffer4, len4);
+  EXPECT_EQ(err, CborNoError);
+  EXPECT_EQ(decode4.header.version, d4.header.version);
+  EXPECT_EQ(decode4.header.reading_time_utc_ms, d4.header.reading_time_utc_ms);
+  EXPECT_EQ(decode4.header.reading_uptime_millis, d4.header.reading_uptime_millis);
+  EXPECT_EQ(decode4.header.sensor_reading_time_ms, d4.header.sensor_reading_time_ms);
+  EXPECT_EQ(decode4.power_reading_type, d4.power_reading_type);
+  EXPECT_EQ(decode4.status, d4.status);
+  EXPECT_EQ(decode4.voltage_v, d4.voltage_v);
+  EXPECT_EQ(decode4.current_a, d4.current_a);
+  EXPECT_EQ(decode4.mpp_position, d4.mpp_position);
+  EXPECT_EQ(decode4.num_temp_sensors, d4.num_temp_sensors);
+  EXPECT_EQ(decode4.num_lines, d4.num_lines);
+  for (size_t i = 0; i < d4.num_temp_sensors; i++) {
+    EXPECT_EQ(decode4.panel_temperatures[i], d4.panel_temperatures[i]);
+  }
+  for (size_t i = 0; i < d4.num_lines; i++) {
+    EXPECT_EQ(decode4.panel_voltages[i], d4.panel_voltages[i]);
+    EXPECT_EQ(decode4.panel_currents[i], d4.panel_currents[i]);
+  }
+
+  free(d4.panel_temperatures);
+  free(d4.panel_voltages);
+  free(d4.panel_currents);
+  free(decode4.panel_temperatures);
+  free(decode4.panel_voltages);
+  free(decode4.panel_currents);
 }

--- a/test/bm_common_messages_tests_ut.cpp
+++ b/test/bm_common_messages_tests_ut.cpp
@@ -970,7 +970,6 @@ TEST_F(BmCommonTest, PowerSolarReadingTest) {
   d.status = PowerReadingMsg::OKAY;
   d.voltage_v = 24.5;
   d.current_a = 8.3;
-  d.mpp_position = 95.5;
   d.num_temp_sensors = 1;
   d.num_lines = 1;
   d.panel_temperatures = (double *)malloc(sizeof(double));
@@ -996,7 +995,6 @@ TEST_F(BmCommonTest, PowerSolarReadingTest) {
   EXPECT_EQ(decode.status, d.status);
   EXPECT_EQ(decode.voltage_v, d.voltage_v);
   EXPECT_EQ(decode.current_a, d.current_a);
-  EXPECT_EQ(decode.mpp_position, d.mpp_position);
   EXPECT_EQ(decode.num_temp_sensors, d.num_temp_sensors);
   EXPECT_EQ(decode.num_lines, d.num_lines);
   EXPECT_EQ(decode.panel_temperatures[0], d.panel_temperatures[0]);
@@ -1030,7 +1028,6 @@ TEST_F(BmCommonTest, PowerSolarReadingTest) {
   d2.status = PowerReadingMsg::OKAY;
   d2.voltage_v = 24.5;
   d2.current_a = 8.3;
-  d2.mpp_position = 95.5;
   d2.num_temp_sensors = 0;
   d2.num_lines = 0;
 
@@ -1050,7 +1047,6 @@ TEST_F(BmCommonTest, PowerSolarReadingTest) {
   EXPECT_EQ(decode2.status, d2.status);
   EXPECT_EQ(decode2.voltage_v, d2.voltage_v);
   EXPECT_EQ(decode2.current_a, d2.current_a);
-  EXPECT_EQ(decode2.mpp_position, d2.mpp_position);
   EXPECT_EQ(decode2.num_temp_sensors, d2.num_temp_sensors);
   EXPECT_EQ(decode2.num_lines, d2.num_lines);
 
@@ -1067,7 +1063,6 @@ TEST_F(BmCommonTest, PowerSolarReadingTest) {
   d3.status = PowerReadingMsg::OKAY;
   d3.voltage_v = 120.0;
   d3.current_a = 40.5;
-  d3.mpp_position = 98.3;
   d3.num_temp_sensors = 5;
   d3.num_lines = 5;
   d3.panel_temperatures = (double *)malloc(sizeof(double) * d3.num_temp_sensors);
@@ -1095,7 +1090,6 @@ TEST_F(BmCommonTest, PowerSolarReadingTest) {
   EXPECT_EQ(decode3.status, d3.status);
   EXPECT_EQ(decode3.voltage_v, d3.voltage_v);
   EXPECT_EQ(decode3.current_a, d3.current_a);
-  EXPECT_EQ(decode3.mpp_position, d3.mpp_position);
   EXPECT_EQ(decode3.num_temp_sensors, d3.num_temp_sensors);
   EXPECT_EQ(decode3.num_lines, d3.num_lines);
   for (size_t i = 0; i < d3.num_temp_sensors; i++) {
@@ -1117,7 +1111,6 @@ TEST_F(BmCommonTest, PowerSolarReadingTest) {
   d4.status = PowerReadingMsg::OKAY;
   d4.voltage_v = 24.5;
   d4.current_a = 8.3;
-  d4.mpp_position = 95.5;
   d4.num_temp_sensors = 1;
   d4.num_lines = 6;
   d4.panel_temperatures = (double *)malloc(sizeof(double) * d4.num_temp_sensors);
@@ -1153,7 +1146,6 @@ TEST_F(BmCommonTest, PowerSolarReadingTest) {
   EXPECT_EQ(decode4.status, d4.status);
   EXPECT_EQ(decode4.voltage_v, d4.voltage_v);
   EXPECT_EQ(decode4.current_a, d4.current_a);
-  EXPECT_EQ(decode4.mpp_position, d4.mpp_position);
   EXPECT_EQ(decode4.num_temp_sensors, d4.num_temp_sensors);
   EXPECT_EQ(decode4.num_lines, d4.num_lines);
   for (size_t i = 0; i < d4.num_temp_sensors; i++) {
@@ -1178,7 +1170,6 @@ TEST_F(BmCommonTest, PowerSolarAveragesTest) {
   d.header.sensor_reading_time_ms = 0xdeadc0de;
   d.power_reading_type = PowerReadingMsg::SOURCE;
   d.status = PowerReadingMsg::OKAY;
-  // d.mpp_position = 95.5;
   d.num_temp_sensors = 1;
   d.num_lines = 1;
   d.panel_temperatures_average = (double *)malloc(sizeof(double));
@@ -1220,7 +1211,6 @@ TEST_F(BmCommonTest, PowerSolarAveragesTest) {
   EXPECT_EQ(decode.header.sensor_reading_time_ms, d.header.sensor_reading_time_ms);
   EXPECT_EQ(decode.power_reading_type, d.power_reading_type);
   EXPECT_EQ(decode.status, d.status);
-  // EXPECT_EQ(decode.mpp_position, d.mpp_position);
   EXPECT_EQ(decode.num_temp_sensors, d.num_temp_sensors);
   EXPECT_EQ(decode.num_lines, d.num_lines);
   EXPECT_EQ(decode.panel_temperatures_average[0], d.panel_temperatures_average[0]);
@@ -1279,7 +1269,6 @@ TEST_F(BmCommonTest, PowerSolarAveragesTest) {
   d2.header.sensor_reading_time_ms = 0xdeadc0de;
   d2.power_reading_type = PowerReadingMsg::SOURCE;
   d2.status = PowerReadingMsg::OKAY;
-  // d2.mpp_position = 95.5;
   d2.num_temp_sensors = 0;
   d2.num_lines = 0;
 
@@ -1297,7 +1286,6 @@ TEST_F(BmCommonTest, PowerSolarAveragesTest) {
   EXPECT_EQ(decode2.header.sensor_reading_time_ms, d2.header.sensor_reading_time_ms);
   EXPECT_EQ(decode2.power_reading_type, d2.power_reading_type);
   EXPECT_EQ(decode2.status, d2.status);
-  // EXPECT_EQ(decode2.mpp_position, d2.mpp_position);
   EXPECT_EQ(decode2.num_temp_sensors, d2.num_temp_sensors);
   EXPECT_EQ(decode2.num_lines, d2.num_lines);
 
@@ -1312,7 +1300,6 @@ TEST_F(BmCommonTest, PowerSolarAveragesTest) {
   d3.header.sensor_reading_time_ms = 0xdeadc0de;
   d3.power_reading_type = PowerReadingMsg::SOURCE;
   d3.status = PowerReadingMsg::OKAY;
-  // d3.mpp_position = 98.3;
   d3.num_temp_sensors = 5;
   d3.num_lines = 5;
   d3.panel_temperatures_average = (double *)malloc(sizeof(double) * d3.num_temp_sensors);
@@ -1356,7 +1343,6 @@ TEST_F(BmCommonTest, PowerSolarAveragesTest) {
   EXPECT_EQ(decode3.header.sensor_reading_time_ms, d3.header.sensor_reading_time_ms);
   EXPECT_EQ(decode3.power_reading_type, d3.power_reading_type);
   EXPECT_EQ(decode3.status, d3.status);
-  // EXPECT_EQ(decode3.mpp_position, d3.mpp_position);
   EXPECT_EQ(decode3.num_temp_sensors, d3.num_temp_sensors);
   EXPECT_EQ(decode3.num_lines, d3.num_lines);
   for (size_t i = 0; i < d3.num_temp_sensors; i++) {
@@ -1387,7 +1373,6 @@ TEST_F(BmCommonTest, PowerSolarAveragesTest) {
   d4.header.sensor_reading_time_ms = 0xdeadc0de;
   d4.power_reading_type = PowerReadingMsg::SOURCE;
   d4.status = PowerReadingMsg::OKAY;
-  // d4.mpp_position = 95.5;
   d4.num_temp_sensors = 1;
   d4.num_lines = 6;
   d4.panel_temperatures_average = (double *)malloc(sizeof(double) * d4.num_temp_sensors);
@@ -1432,7 +1417,6 @@ TEST_F(BmCommonTest, PowerSolarAveragesTest) {
   EXPECT_EQ(decode4.header.sensor_reading_time_ms, d4.header.sensor_reading_time_ms);
   EXPECT_EQ(decode4.power_reading_type, d4.power_reading_type);
   EXPECT_EQ(decode4.status, d4.status);
-  // EXPECT_EQ(decode4.mpp_position, d4.mpp_position);
   EXPECT_EQ(decode4.num_temp_sensors, d4.num_temp_sensors);
   EXPECT_EQ(decode4.num_lines, d4.num_lines);
   for (size_t i = 0; i < d4.num_temp_sensors; i++) {

--- a/test/bm_common_messages_tests_ut.cpp
+++ b/test/bm_common_messages_tests_ut.cpp
@@ -18,6 +18,7 @@
 #include "power_battery_msg.h"
 #include "power_reading_averages_msg.h"
 #include "power_reading_msg.h"
+#include "power_solar_averages_msg.h"
 #include "power_solar_reading_msg.h"
 #include "power_solar_reading_msg.h"
 #include "sensor_header_msg.h"

--- a/test/bm_common_messages_tests_ut.cpp
+++ b/test/bm_common_messages_tests_ut.cpp
@@ -20,7 +20,6 @@
 #include "power_reading_msg.h"
 #include "power_solar_averages_msg.h"
 #include "power_solar_reading_msg.h"
-#include "power_solar_reading_msg.h"
 #include "sensor_header_msg.h"
 #include "sys_info_svc_reply_msg.h"
 #include "gtest/gtest.h"
@@ -1167,4 +1166,292 @@ TEST_F(BmCommonTest, PowerSolarReadingTest) {
 
   PowerSolarReadingMsg::free(d4);
   PowerSolarReadingMsg::free(decode4);
+}
+
+TEST_F(BmCommonTest, PowerSolarAveragesTest) {
+  CborError err = CborNoError;
+  // Test with nun_temps_sensors and num_lines == 1
+  PowerSolarAveragesMsg::Data d;
+  d.header.version = PowerSolarAveragesMsg::VERSION;
+  d.header.reading_time_utc_ms = 123456789;
+  d.header.reading_uptime_millis = 987654321;
+  d.header.sensor_reading_time_ms = 0xdeadc0de;
+  d.power_reading_type = PowerReadingMsg::SOURCE;
+  d.status = PowerReadingMsg::OKAY;
+  // d.mpp_position = 95.5;
+  d.num_temp_sensors = 1;
+  d.num_lines = 1;
+  d.panel_temperatures_average = (double *)malloc(sizeof(double));
+  d.panel_temperatures_average[0] = 45.2;
+  d.panel_temperatures_max = (double *)malloc(sizeof(double));
+  d.panel_temperatures_max[0] = 45.2;
+  d.panel_temperatures_min = (double *)malloc(sizeof(double));
+  d.panel_temperatures_min[0] = 45.2;
+  d.panel_temperatures_stdev = (double *)malloc(sizeof(double));
+  d.panel_temperatures_stdev[0] = 45.2;
+  d.panel_voltages_average = (double *)malloc(sizeof(double));
+  d.panel_voltages_average[0] = 24.5;
+  d.panel_voltages_max = (double *)malloc(sizeof(double));
+  d.panel_voltages_max[0] = 24.5;
+  d.panel_voltages_min = (double *)malloc(sizeof(double));
+  d.panel_voltages_min[0] = 24.5;
+  d.panel_voltages_stdev = (double *)malloc(sizeof(double));
+  d.panel_voltages_stdev[0] = 24.5;
+  d.panel_currents_average = (double *)malloc(sizeof(double));
+  d.panel_currents_average[0] = 8.3;
+  d.panel_currents_max = (double *)malloc(sizeof(double));
+  d.panel_currents_max[0] = 8.3;
+  d.panel_currents_min = (double *)malloc(sizeof(double));
+  d.panel_currents_min[0] = 8.3;
+  d.panel_currents_stdev = (double *)malloc(sizeof(double));
+  d.panel_currents_stdev[0] = 8.3;
+
+  uint8_t cbor_buffer[1024];
+  size_t len = 0;
+  PowerSolarAveragesMsg::encode(d, cbor_buffer, sizeof(cbor_buffer), &len);
+  EXPECT_EQ(len, 551);
+
+  PowerSolarAveragesMsg::Data decode = {};
+  err = PowerSolarAveragesMsg::decode(decode, cbor_buffer, len);
+  EXPECT_EQ(err, CborNoError);
+  EXPECT_EQ(decode.header.version, d.header.version);
+  EXPECT_EQ(decode.header.reading_time_utc_ms, d.header.reading_time_utc_ms);
+  EXPECT_EQ(decode.header.reading_uptime_millis, d.header.reading_uptime_millis);
+  EXPECT_EQ(decode.header.sensor_reading_time_ms, d.header.sensor_reading_time_ms);
+  EXPECT_EQ(decode.power_reading_type, d.power_reading_type);
+  EXPECT_EQ(decode.status, d.status);
+  // EXPECT_EQ(decode.mpp_position, d.mpp_position);
+  EXPECT_EQ(decode.num_temp_sensors, d.num_temp_sensors);
+  EXPECT_EQ(decode.num_lines, d.num_lines);
+  EXPECT_EQ(decode.panel_temperatures_average[0], d.panel_temperatures_average[0]);
+  EXPECT_EQ(decode.panel_temperatures_max[0], d.panel_temperatures_max[0]);
+  EXPECT_EQ(decode.panel_temperatures_min[0], d.panel_temperatures_min[0]);
+  EXPECT_EQ(decode.panel_temperatures_stdev[0], d.panel_temperatures_stdev[0]);
+  EXPECT_EQ(decode.panel_voltages_average[0], d.panel_voltages_average[0]);
+  EXPECT_EQ(decode.panel_voltages_max[0], d.panel_voltages_max[0]);
+  EXPECT_EQ(decode.panel_voltages_min[0], d.panel_voltages_min[0]);
+  EXPECT_EQ(decode.panel_voltages_stdev[0], d.panel_voltages_stdev[0]);
+  EXPECT_EQ(decode.panel_currents_average[0], d.panel_currents_average[0]);
+  EXPECT_EQ(decode.panel_currents_max[0], d.panel_currents_max[0]);
+  EXPECT_EQ(decode.panel_currents_min[0], d.panel_currents_min[0]);
+  EXPECT_EQ(decode.panel_currents_stdev[0], d.panel_currents_stdev[0]);
+
+  PowerSolarAveragesMsg::free(d);
+  PowerSolarAveragesMsg::free(decode);
+
+  // Test to make sure the pointers get set to NULL
+  EXPECT_FALSE(d.panel_temperatures_average);
+  EXPECT_FALSE(d.panel_temperatures_max);
+  EXPECT_FALSE(d.panel_temperatures_min);
+  EXPECT_FALSE(d.panel_temperatures_stdev);
+  EXPECT_FALSE(d.panel_voltages_average);
+  EXPECT_FALSE(d.panel_voltages_max);
+  EXPECT_FALSE(d.panel_voltages_min);
+  EXPECT_FALSE(d.panel_voltages_stdev);
+  EXPECT_FALSE(d.panel_currents_average);
+  EXPECT_FALSE(d.panel_currents_max);
+  EXPECT_FALSE(d.panel_currents_min);
+  EXPECT_FALSE(d.panel_currents_stdev);
+
+  // Should be safe to call again, i.e. won't crash test
+  PowerSolarAveragesMsg::free(d);
+  PowerSolarAveragesMsg::free(decode);
+
+  // Check the pointers are still NULL
+  EXPECT_FALSE(d.panel_temperatures_average);
+  EXPECT_FALSE(d.panel_temperatures_max);
+  EXPECT_FALSE(d.panel_temperatures_min);
+  EXPECT_FALSE(d.panel_temperatures_stdev);
+  EXPECT_FALSE(d.panel_voltages_average);
+  EXPECT_FALSE(d.panel_voltages_max);
+  EXPECT_FALSE(d.panel_voltages_min);
+  EXPECT_FALSE(d.panel_voltages_stdev);
+  EXPECT_FALSE(d.panel_currents_average);
+  EXPECT_FALSE(d.panel_currents_max);
+  EXPECT_FALSE(d.panel_currents_min);
+  EXPECT_FALSE(d.panel_currents_stdev);
+
+  // Test with num_temp_sensors and num_lines == 0
+  PowerSolarAveragesMsg::Data d2 = {};
+  d2.header.version = PowerSolarReadingMsg::VERSION;
+  d2.header.reading_time_utc_ms = 123456789;
+  d2.header.reading_uptime_millis = 987654321;
+  d2.header.sensor_reading_time_ms = 0xdeadc0de;
+  d2.power_reading_type = PowerReadingMsg::SOURCE;
+  d2.status = PowerReadingMsg::OKAY;
+  // d2.mpp_position = 95.5;
+  d2.num_temp_sensors = 0;
+  d2.num_lines = 0;
+
+  uint8_t cbor_buffer2[1024];
+  size_t len2 = 0;
+  PowerSolarAveragesMsg::encode(d2, cbor_buffer2, sizeof(cbor_buffer2), &len2);
+  EXPECT_EQ(len2, 443);
+
+  PowerSolarAveragesMsg::Data decode2 = {};
+  err = PowerSolarAveragesMsg::decode(decode2, cbor_buffer2, len2);
+  EXPECT_EQ(err, CborNoError);
+  EXPECT_EQ(decode2.header.version, d2.header.version);
+  EXPECT_EQ(decode2.header.reading_time_utc_ms, d2.header.reading_time_utc_ms);
+  EXPECT_EQ(decode2.header.reading_uptime_millis, d2.header.reading_uptime_millis);
+  EXPECT_EQ(decode2.header.sensor_reading_time_ms, d2.header.sensor_reading_time_ms);
+  EXPECT_EQ(decode2.power_reading_type, d2.power_reading_type);
+  EXPECT_EQ(decode2.status, d2.status);
+  // EXPECT_EQ(decode2.mpp_position, d2.mpp_position);
+  EXPECT_EQ(decode2.num_temp_sensors, d2.num_temp_sensors);
+  EXPECT_EQ(decode2.num_lines, d2.num_lines);
+
+  PowerSolarAveragesMsg::free(d2);
+  PowerSolarAveragesMsg::free(decode2);
+
+  // Test with num_temp_sensors and num_lines == 5
+  PowerSolarAveragesMsg::Data d3;
+  d3.header.version = PowerSolarAveragesMsg::VERSION;
+  d3.header.reading_time_utc_ms = 123456789;
+  d3.header.reading_uptime_millis = 987654321;
+  d3.header.sensor_reading_time_ms = 0xdeadc0de;
+  d3.power_reading_type = PowerReadingMsg::SOURCE;
+  d3.status = PowerReadingMsg::OKAY;
+  // d3.mpp_position = 98.3;
+  d3.num_temp_sensors = 5;
+  d3.num_lines = 5;
+  d3.panel_temperatures_average = (double *)malloc(sizeof(double) * d3.num_temp_sensors);
+  d3.panel_temperatures_max = (double *)malloc(sizeof(double) * d3.num_temp_sensors);
+  d3.panel_temperatures_min = (double *)malloc(sizeof(double) * d3.num_temp_sensors);
+  d3.panel_temperatures_stdev = (double *)malloc(sizeof(double) * d3.num_temp_sensors);
+  d3.panel_voltages_average = (double *)malloc(sizeof(double) * d3.num_lines);
+  d3.panel_voltages_max = (double *)malloc(sizeof(double) * d3.num_lines);
+  d3.panel_voltages_min = (double *)malloc(sizeof(double) * d3.num_lines);
+  d3.panel_voltages_stdev = (double *)malloc(sizeof(double) * d3.num_lines);
+  d3.panel_currents_average = (double *)malloc(sizeof(double) * d3.num_lines);
+  d3.panel_currents_max = (double *)malloc(sizeof(double) * d3.num_lines);
+  d3.panel_currents_min = (double *)malloc(sizeof(double) * d3.num_lines);
+  d3.panel_currents_stdev = (double *)malloc(sizeof(double) * d3.num_lines);
+  for (size_t i = 0; i < d3.num_temp_sensors; i++) {
+    d3.panel_temperatures_average[i] = 45.0 + i * 0.5;
+    d3.panel_temperatures_max[i] = 45.0 + i * 0.5;
+    d3.panel_temperatures_min[i] = 45.0 + i * 0.5;
+    d3.panel_temperatures_stdev[i] = 45.0 + i * 0.5;
+    d3.panel_voltages_average[i] = 24.0 + i * 0.1;
+    d3.panel_voltages_max[i] = 24.0 + i * 0.1;
+    d3.panel_voltages_min[i] = 24.0 + i * 0.1;
+    d3.panel_voltages_stdev[i] = 24.0 + i * 0.1;
+    d3.panel_currents_average[i] = 8.0 + i * 0.05;
+    d3.panel_currents_max[i] = 8.0 + i * 0.05;
+    d3.panel_currents_min[i] = 8.0 + i * 0.05;
+    d3.panel_currents_stdev[i] = 8.0 + i * 0.05;
+  }
+
+  uint8_t cbor_buffer3[1024];
+  size_t len3 = 0;
+  PowerSolarAveragesMsg::encode(d3, cbor_buffer3, sizeof(cbor_buffer3), &len3);
+  EXPECT_EQ(len3, 983);
+
+  PowerSolarAveragesMsg::Data decode3 = {};
+  err = PowerSolarAveragesMsg::decode(decode3, cbor_buffer3, len3);
+  EXPECT_EQ(err, CborNoError);
+  EXPECT_EQ(decode3.header.version, d3.header.version);
+  EXPECT_EQ(decode3.header.reading_time_utc_ms, d3.header.reading_time_utc_ms);
+  EXPECT_EQ(decode3.header.reading_uptime_millis, d3.header.reading_uptime_millis);
+  EXPECT_EQ(decode3.header.sensor_reading_time_ms, d3.header.sensor_reading_time_ms);
+  EXPECT_EQ(decode3.power_reading_type, d3.power_reading_type);
+  EXPECT_EQ(decode3.status, d3.status);
+  // EXPECT_EQ(decode3.mpp_position, d3.mpp_position);
+  EXPECT_EQ(decode3.num_temp_sensors, d3.num_temp_sensors);
+  EXPECT_EQ(decode3.num_lines, d3.num_lines);
+  for (size_t i = 0; i < d3.num_temp_sensors; i++) {
+    EXPECT_EQ(decode3.panel_temperatures_average[i], d3.panel_temperatures_average[i]);
+    EXPECT_EQ(decode3.panel_temperatures_max[i], d3.panel_temperatures_max[i]);
+    EXPECT_EQ(decode3.panel_temperatures_min[i], d3.panel_temperatures_min[i]);
+    EXPECT_EQ(decode3.panel_temperatures_stdev[i], d3.panel_temperatures_stdev[i]);
+  }
+  for (size_t i = 0; i < d3.num_lines; i++) {
+    EXPECT_EQ(decode3.panel_voltages_average[i], d3.panel_voltages_average[i]);
+    EXPECT_EQ(decode3.panel_voltages_max[i], d3.panel_voltages_max[i]);
+    EXPECT_EQ(decode3.panel_voltages_min[i], d3.panel_voltages_min[i]);
+    EXPECT_EQ(decode3.panel_voltages_stdev[i], d3.panel_voltages_stdev[i]);
+    EXPECT_EQ(decode3.panel_currents_average[i], d3.panel_currents_average[i]);
+    EXPECT_EQ(decode3.panel_currents_max[i], d3.panel_currents_max[i]);
+    EXPECT_EQ(decode3.panel_currents_min[i], d3.panel_currents_min[i]);
+    EXPECT_EQ(decode3.panel_currents_stdev[i], d3.panel_currents_stdev[i]);
+  }
+
+  PowerSolarAveragesMsg::free(d3);
+  PowerSolarAveragesMsg::free(decode3);
+
+  // Test with nun_temps_sensors == 1 and num_lines == 6
+  PowerSolarAveragesMsg::Data d4;
+  d4.header.version = PowerSolarAveragesMsg::VERSION;
+  d4.header.reading_time_utc_ms = 123456789;
+  d4.header.reading_uptime_millis = 987654321;
+  d4.header.sensor_reading_time_ms = 0xdeadc0de;
+  d4.power_reading_type = PowerReadingMsg::SOURCE;
+  d4.status = PowerReadingMsg::OKAY;
+  // d4.mpp_position = 95.5;
+  d4.num_temp_sensors = 1;
+  d4.num_lines = 6;
+  d4.panel_temperatures_average = (double *)malloc(sizeof(double) * d4.num_temp_sensors);
+  d4.panel_temperatures_max = (double *)malloc(sizeof(double) * d4.num_temp_sensors);
+  d4.panel_temperatures_min = (double *)malloc(sizeof(double) * d4.num_temp_sensors);
+  d4.panel_temperatures_stdev = (double *)malloc(sizeof(double) * d4.num_temp_sensors);
+  d4.panel_temperatures_average[0] = 45.2;
+  d4.panel_temperatures_max[0] = 45.2;
+  d4.panel_temperatures_min[0] = 45.2;
+  d4.panel_temperatures_stdev[0] = 45.2;
+  d4.panel_voltages_average = (double *)malloc(sizeof(double) * d4.num_lines);
+  d4.panel_voltages_max = (double *)malloc(sizeof(double) * d4.num_lines);
+  d4.panel_voltages_min = (double *)malloc(sizeof(double) * d4.num_lines);
+  d4.panel_voltages_stdev = (double *)malloc(sizeof(double) * d4.num_lines);
+  d4.panel_currents_average = (double *)malloc(sizeof(double)* d4.num_lines);
+  d4.panel_currents_max = (double *)malloc(sizeof(double)* d4.num_lines);
+  d4.panel_currents_min = (double *)malloc(sizeof(double)* d4.num_lines);
+  d4.panel_currents_stdev = (double *)malloc(sizeof(double)* d4.num_lines);
+
+  for (uint8_t i = 0; i < d4.num_lines; i++) {
+    d4.panel_voltages_average[i] = 24.5;
+    d4.panel_voltages_max[i] = 25.68;
+    d4.panel_voltages_min[i] = 22.09;
+    d4.panel_voltages_stdev[i] = 0.123;
+    d4.panel_currents_average[i] = 8.5;
+    d4.panel_currents_max[i] = 9.68;
+    d4.panel_currents_min[i] = 4.59;
+    d4.panel_currents_stdev[i] = 0.123;
+  }
+
+  uint8_t cbor_buffer4[1024];
+  size_t len4 = 0;
+  PowerSolarAveragesMsg::encode(d4, cbor_buffer4, sizeof(cbor_buffer4), &len4);
+  EXPECT_EQ(len4, 911);
+
+  PowerSolarAveragesMsg::Data decode4 = {};
+  err = PowerSolarAveragesMsg::decode(decode4, cbor_buffer4, len4);
+  EXPECT_EQ(err, CborNoError);
+  EXPECT_EQ(decode4.header.version, d4.header.version);
+  EXPECT_EQ(decode4.header.reading_time_utc_ms, d4.header.reading_time_utc_ms);
+  EXPECT_EQ(decode4.header.reading_uptime_millis, d4.header.reading_uptime_millis);
+  EXPECT_EQ(decode4.header.sensor_reading_time_ms, d4.header.sensor_reading_time_ms);
+  EXPECT_EQ(decode4.power_reading_type, d4.power_reading_type);
+  EXPECT_EQ(decode4.status, d4.status);
+  // EXPECT_EQ(decode4.mpp_position, d4.mpp_position);
+  EXPECT_EQ(decode4.num_temp_sensors, d4.num_temp_sensors);
+  EXPECT_EQ(decode4.num_lines, d4.num_lines);
+  for (size_t i = 0; i < d4.num_temp_sensors; i++) {
+    EXPECT_EQ(decode4.panel_temperatures_average[i], d4.panel_temperatures_average[i]);
+    EXPECT_EQ(decode4.panel_temperatures_max[i], d4.panel_temperatures_max[i]);
+    EXPECT_EQ(decode4.panel_temperatures_min[i], d4.panel_temperatures_min[i]);
+    EXPECT_EQ(decode4.panel_temperatures_stdev[i], d4.panel_temperatures_stdev[i]);
+  }
+  for (size_t i = 0; i < d4.num_lines; i++) {
+    EXPECT_EQ(decode4.panel_voltages_average[i], d4.panel_voltages_average[i]);
+    EXPECT_EQ(decode4.panel_voltages_max[i], d4.panel_voltages_max[i]);
+    EXPECT_EQ(decode4.panel_voltages_min[i], d4.panel_voltages_min[i]);
+    EXPECT_EQ(decode4.panel_voltages_stdev[i], d4.panel_voltages_stdev[i]);
+    EXPECT_EQ(decode4.panel_currents_average[i], d4.panel_currents_average[i]);
+    EXPECT_EQ(decode4.panel_currents_max[i], d4.panel_currents_max[i]);
+    EXPECT_EQ(decode4.panel_currents_min[i], d4.panel_currents_min[i]);
+    EXPECT_EQ(decode4.panel_currents_stdev[i], d4.panel_currents_stdev[i]);
+  }
+
+  PowerSolarAveragesMsg::free(d4);
+  PowerSolarAveragesMsg::free(decode4);
 }

--- a/test/bm_common_messages_tests_ut.cpp
+++ b/test/bm_common_messages_tests_ut.cpp
@@ -960,7 +960,7 @@ TEST_F(BmCommonTest, PowerBatteryAveragesTest) {
 
 TEST_F(BmCommonTest, PowerSolarReadingTest) {
   CborError err = CborNoError;
-  // Test with nun_temps_sensors and num_lines == 1
+  // Test with nun_temp_sensors and num_lines == 1
   PowerSolarReadingMsg::Data d;
   d.header.version = PowerSolarReadingMsg::VERSION;
   d.header.reading_time_utc_ms = 123456789;
@@ -1101,7 +1101,7 @@ TEST_F(BmCommonTest, PowerSolarReadingTest) {
   PowerSolarReadingMsg::free(d3);
   PowerSolarReadingMsg::free(decode3);
 
-  // Test with nun_temps_sensors == 1 and num_lines == 6
+  // Test with nun_temp_sensors == 1 and num_lines == 6
   PowerSolarReadingMsg::Data d4;
   d4.header.version = PowerSolarReadingMsg::VERSION;
   d4.header.reading_time_utc_ms = 123456789;
@@ -1162,7 +1162,7 @@ TEST_F(BmCommonTest, PowerSolarReadingTest) {
 
 TEST_F(BmCommonTest, PowerSolarAveragesTest) {
   CborError err = CborNoError;
-  // Test with nun_temps_sensors and num_lines == 1
+  // Test with nun_temp_sensors and num_lines == 1
   PowerSolarAveragesMsg::Data d;
   d.header.version = PowerSolarAveragesMsg::VERSION;
   d.header.reading_time_utc_ms = 123456789;
@@ -1365,7 +1365,7 @@ TEST_F(BmCommonTest, PowerSolarAveragesTest) {
   PowerSolarAveragesMsg::free(d3);
   PowerSolarAveragesMsg::free(decode3);
 
-  // Test with nun_temps_sensors == 1 and num_lines == 6
+  // Test with nun_temp_sensors == 1 and num_lines == 6
   PowerSolarAveragesMsg::Data d4;
   d4.header.version = PowerSolarAveragesMsg::VERSION;
   d4.header.reading_time_utc_ms = 123456789;

--- a/test/bm_common_messages_tests_ut.cpp
+++ b/test/bm_common_messages_tests_ut.cpp
@@ -1003,12 +1003,22 @@ TEST_F(BmCommonTest, PowerSolarReadingTest) {
   EXPECT_EQ(decode.panel_voltages[0], d.panel_voltages[0]);
   EXPECT_EQ(decode.panel_currents[0], d.panel_currents[0]);
 
-  free(d.panel_temperatures);
-  free(d.panel_voltages);
-  free(d.panel_currents);
-  free(decode.panel_temperatures);
-  free(decode.panel_voltages);
-  free(decode.panel_currents);
+  PowerSolarReadingMsg::free(d);
+  PowerSolarReadingMsg::free(decode);
+
+  // Test to make sure the pointers get set to NULL
+  EXPECT_FALSE(d.panel_temperatures);
+  EXPECT_FALSE(d.panel_voltages);
+  EXPECT_FALSE(d.panel_currents);
+
+  // Should be safe to call again, i.e. won't crash test
+  PowerSolarReadingMsg::free(d);
+  PowerSolarReadingMsg::free(decode);
+
+  // Check the pointers are still NULL
+  EXPECT_FALSE(d.panel_temperatures);
+  EXPECT_FALSE(d.panel_voltages);
+  EXPECT_FALSE(d.panel_currents);
 
   // Test with num_temp_sensors and num_lines == 0
   PowerSolarReadingMsg::Data d2 = {};
@@ -1043,6 +1053,9 @@ TEST_F(BmCommonTest, PowerSolarReadingTest) {
   EXPECT_EQ(decode2.mpp_position, d2.mpp_position);
   EXPECT_EQ(decode2.num_temp_sensors, d2.num_temp_sensors);
   EXPECT_EQ(decode2.num_lines, d2.num_lines);
+
+  PowerSolarReadingMsg::free(d2);
+  PowerSolarReadingMsg::free(decode2);
 
   // Test with num_temp_sensors and num_lines == 5
   PowerSolarReadingMsg::Data d3;
@@ -1091,12 +1104,8 @@ TEST_F(BmCommonTest, PowerSolarReadingTest) {
     EXPECT_EQ(decode3.panel_currents[i], d3.panel_currents[i]);
   }
 
-  free(d3.panel_temperatures);
-  free(d3.panel_voltages);
-  free(d3.panel_currents);
-  free(decode3.panel_temperatures);
-  free(decode3.panel_voltages);
-  free(decode3.panel_currents);
+  PowerSolarReadingMsg::free(d3);
+  PowerSolarReadingMsg::free(decode3);
 
   // Test with nun_temps_sensors == 1 and num_lines == 6
   PowerSolarReadingMsg::Data d4;
@@ -1155,10 +1164,6 @@ TEST_F(BmCommonTest, PowerSolarReadingTest) {
     EXPECT_EQ(decode4.panel_currents[i], d4.panel_currents[i]);
   }
 
-  free(d4.panel_temperatures);
-  free(d4.panel_voltages);
-  free(d4.panel_currents);
-  free(decode4.panel_temperatures);
-  free(decode4.panel_voltages);
-  free(decode4.panel_currents);
+  PowerSolarReadingMsg::free(d4);
+  PowerSolarReadingMsg::free(decode4);
 }


### PR DESCRIPTION
# What Changed:
Adding the solar power averages reading message and the associated encoding/decoding functions and unit tests.

Also removes MPP from solar reading since it can be calculated from the data that is already provided.

# How does it make Bristlemouth better?
This adds a standard solar averages reading message to Bristlemouth!

Where should reviewers focus?
On the overall pr, there is nothing new in terms of implementation, this pr follows the same patterns as prior messages.

# Testing

Here is an example of Spotter publishing faked solar averaged reading and a mote subscribed and printing it out:
Spotter:
<img width="655" height="162" alt="Screenshot 2026-03-02 at 4 09 33 PM" src="https://github.com/user-attachments/assets/182eec8f-6dee-4a89-ad8b-f3576e62d606" />


Mote:
<img width="517" height="246" alt="Screenshot 2026-03-02 at 4 09 21 PM" src="https://github.com/user-attachments/assets/10f7ad14-0911-4e7e-bb52-7316a370b086" />



