### PR TITLE
remove freertos dependency from these message files

### DIFF
--- a/device_test_svc_reply_msg.cpp
+++ b/device_test_svc_reply_msg.cpp
@@ -1,7 +1,7 @@
 #include "device_test_svc_reply_msg.h"
 #include "bm_config.h"
 #ifndef CI_TEST
-#include "FreeRTOS.h"
+#include "bm_os.h"
 #else // CI_TEST
 #include <cstdlib>
 #endif // CI_TEST
@@ -178,8 +178,9 @@ CborError DeviceTestSvcReplyMsg::decode(Data &d, const uint8_t *cbor_buffer,
     if (d.data_len) {
       size_t buflen = d.data_len;
 #ifndef CI_TEST
-      uint8_t *buf = static_cast<uint8_t *>(pvPortMalloc(buflen));
-      configASSERT(buf);
+      uint8_t *buf = static_cast<uint8_t *>(bm_malloc(buflen));
+      // TODO - figure out how to replace this
+      // configASSERT(buf);
 #else
       uint8_t *buf = static_cast<uint8_t *>(malloc(buflen));
 #endif // CI_TEST

--- a/device_test_svc_request_msg.cpp
+++ b/device_test_svc_request_msg.cpp
@@ -1,7 +1,7 @@
 #include "device_test_svc_request_msg.h"
 #include "bm_config.h"
 #ifndef CI_TEST
-#include "FreeRTOS.h"
+#include "bm_os.h"
 #else // CI_TEST
 #include <cstdlib>
 #endif // CI_TEST
@@ -142,8 +142,9 @@ CborError DeviceTestSvcRequestMsg::decode(Data &d, const uint8_t *cbor_buffer,
     if (d.data_len) {
       size_t buflen = d.data_len;
 #ifndef CI_TEST
-      uint8_t *buf = static_cast<uint8_t *>(pvPortMalloc(buflen));
-      configASSERT(buf);
+      uint8_t *buf = static_cast<uint8_t *>(bm_malloc(buflen));
+      // TODO - figure out how to replace this
+      // configASSERT(buf);
 #else
       uint8_t *buf = static_cast<uint8_t *>(malloc(buflen));
 #endif // CI_TEST


### PR DESCRIPTION
I noticed we get compilation errors when trying to say include freertos tracing into bm_core files. I was able to identify that it was because of the inclusion of freertos here still, which should idealy be removed.