### PR TITLE
Added metrics reply logic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,7 @@ set(SOURCES
     sensor_header_msg.cpp
     sensor_header_msg.c
     sys_info_svc_reply_msg.c
+    metrics_reply_msg.c 
 )
 
 add_library(bmmessages ${SOURCES})

--- a/bm_messages_helper.c
+++ b/bm_messages_helper.c
@@ -100,6 +100,21 @@ CborError encode_key_value_uint32(CborEncoder *map_encoder, const char *name,
   return err;
 }
 
+CborError encode_key_value_uint64(CborEncoder *map_encoder, const char *name,
+                                  const uint64_t value) {
+  CborError err;
+  if ((err = cbor_encode_text_stringz(map_encoder, name)) != CborNoError) {
+    bm_debug("error: %s(%s): cbor_encode_text_stringz() failed: %d\r\n",
+             __func__, name, err);
+    if (err != CborErrorOutOfMemory)
+      return err;
+  }
+  if ((err = cbor_encode_uint(map_encoder, value)) != CborNoError)
+    bm_debug("error: %s(%s): cbor_encode_uint() failed: %d\r\n", __func__, name,
+             err);
+  return err;
+}
+
 CborError encode_key_value_string(CborEncoder *map_encoder, const char *name,
                                   const char *value, const size_t len) {
   CborError err;
@@ -319,6 +334,24 @@ CborError decode_key_value_uint32(uint32_t *out, CborValue *value,
   *out = (uint32_t)tmp;
 
   return err;
+}
+
+
+CborError decode_key_value_uint64(uint64_t *out, CborValue *value,
+                                  const char *key_expected) {
+  CborError err;
+  if (!cbor_value_is_text_string(value)) {
+    bm_debug("error: %s(%s): expected string key but got something else\r\n",
+             __func__, key_expected);
+    return CborErrorIllegalType;
+  }
+  if ((err = cbor_value_advance(value)) != CborNoError)
+    return err;
+  if (!cbor_value_is_unsigned_integer(value))
+    return CborErrorIllegalType;
+  if ((err = cbor_value_get_uint64(value, out)) != CborNoError)
+    return err;
+  return cbor_value_advance(value);
 }
 
 static CborError decode_key_value_string_bytes(void **out, size_t *len,

--- a/bm_messages_helper.h
+++ b/bm_messages_helper.h
@@ -58,6 +58,8 @@ CborError encode_key_value_uint8(CborEncoder *map_encoder, const char *name,
                                  const uint8_t value);
 CborError encode_key_value_uint32(CborEncoder *map_encoder, const char *name,
                                   const uint32_t value);
+CborError encode_key_value_uint64(CborEncoder *map_encoder, const char *name,
+                                  const uint64_t value);
 CborError encode_key_value_string(CborEncoder *map_encoder, const char *name,
                                   const char *value, const size_t len);
 CborError encode_key_value_bytes(CborEncoder *map_encoder, const char *name,
@@ -78,6 +80,8 @@ CborError decode_key_value_double(double *out, CborValue *value,
 CborError decode_key_value_uint8(uint8_t *out, CborValue *value,
                                  const char *key_expected);
 CborError decode_key_value_uint32(uint32_t *out, CborValue *value,
+                                  const char *key_expected);
+CborError decode_key_value_uint64(uint64_t *out, CborValue *value,
                                   const char *key_expected);
 CborError decode_key_value_string(char **out, size_t *len, CborValue *value,
                                   const char *key_expected);

--- a/metrics_reply_msg.c
+++ b/metrics_reply_msg.c
@@ -1,39 +1,118 @@
 #include "metrics_reply_msg.h"
-#include "bm_messages_helper.h"
 
 CborError metrics_reply_encode(const MetricsReplyData *d, uint8_t *cbor_buffer,
                                size_t size, size_t *encoded_len) {
-    CborError err;
-    CborEncoder encoder, map_encoder, port_array, port_map;
+  CborError err;
+  CborEncoder encoder, map_encoder, data_map, comp_map;
 
-    err = encoder_message_create(&encoder, &map_encoder, cbor_buffer, size,
-                                METRICS_REPLY_NUM_FIELDS);
+  err = encoder_message_create(&encoder, &map_encoder, cbor_buffer, size,
+                               METRICS_REPLY_NUM_FIELDS);
 
-    check_and_encode_key(err, encode_key_value_uint8(&map_encoder, "v", d->version));
-    check_and_encode_key(err, cbor_encode_text_stringz(&map_encoder, "node"));
-    check_and_encode_key(err, cbor_encode_uint(&map_encoder, d->node_id));
-    check_and_encode_key(err, encode_key_value_uint32(&map_encoder, "up", d->uptime_ms));
+  check_and_encode_key(err, encode_key_value_uint8(&map_encoder, "mv", d->version));
+  check_and_encode_key(err, cbor_encode_text_stringz(&map_encoder, "node"));
+  check_and_encode_key(err, cbor_encode_uint(&map_encoder, d->node_id));
+  check_and_encode_key(err, encode_key_value_uint32(&map_encoder, "up", d->uptime_ms));
 
-    // "p": [ {port0}, {port1}, ... ] 
-    check_and_encode_key(err, cbor_encode_text_stringz(&map_encoder, "p"));
-    check_and_encode_key(err, cbor_encoder_create_array(&map_encoder, &port_array, d->num_ports));
-    for (uint8_t i = 0; i < d->num_ports; i++) {
-        check_and_encode_key(err, cbor_encoder_create_map(&port_array, &port_map, METRICS_PORT_NUM_FIELDS));
-        check_and_encode_key(err, encode_key_value_uint32(&port_map, "mse", d->ports[i].mse_val));
-        check_and_encode_key(err, encode_key_value_uint8(&port_map, "sqi", d->ports[i].sqi));
-        check_and_encode_key(err, encode_key_value_uint8(&port_map, "lq",  d->ports[i].link_quality));
-        check_and_encode_key(err, encode_key_value_uint32(&port_map, "rxe", d->ports[i].rx_err_count));
-        check_and_encode_key(err, encode_key_value_uint32(&port_map, "sye", d->ports[i].symbol_err_count));
-        check_and_encode_key(err, cbor_encoder_close_container(&port_array, &port_map));
-    }
-    check_and_encode_key(err, cbor_encoder_close_container(&map_encoder, &port_array));
+  // "data": { "<component key>": { <flat fields> }, ... }
+  check_and_encode_key(err, cbor_encode_text_stringz(&map_encoder, "data"));
+  check_and_encode_key(err, cbor_encoder_create_map(&map_encoder, &data_map,
+                                                     d->num_components));
+  for (size_t i = 0; i < d->num_components; i++) {
+    const MetricsComponent *c = &d->components[i];
+    check_and_encode_key(err, cbor_encode_text_stringz(&data_map, c->key));
+    check_and_encode_key(err, cbor_encoder_create_map(&data_map, &comp_map,
+                                                       c->num_fields));
+    check_and_encode_key(err, bm_encode_fields_from_table(&comp_map, c->fields,
+                                                          c->num_fields));
+    check_and_encode_key(err, cbor_encoder_close_container(&data_map, &comp_map));
+  }
+  check_and_encode_key(err, cbor_encoder_close_container(&map_encoder, &data_map));
 
-    if (check_acceptable_encode_errors(err)) {
-        err = encoder_message_finish(&encoder, &map_encoder);
-        *encoded_len = cbor_encoder_get_buffer_size(&encoder, cbor_buffer);
-    }
+  if (check_acceptable_encode_errors(err)) {
+    err = encoder_message_finish(&encoder, &map_encoder);
+    *encoded_len = cbor_encoder_get_buffer_size(&encoder, cbor_buffer);
+  }
 
-    encoder_message_check_memory(&encoder, err);
+  encoder_message_check_memory(&encoder, err);
 
+  return err;
+}
+
+static CborError metrics_decode_uint(const CborValue *value, uint64_t *out) {
+  if (!cbor_value_is_unsigned_integer(value)) {
+    return CborErrorIllegalType;
+  }
+  return cbor_value_get_uint64(value, out);
+}
+
+CborError metrics_reply_decode(const uint8_t *cbor_buffer, size_t size,
+                               const MetricsReplyDecode *out) {
+  CborParser parser;
+  CborValue map, value, data_map, comp, field;
+  CborError err;
+  uint64_t tmp;
+
+  err = cbor_parser_init(cbor_buffer, size, 0, &parser, &map);
+  if (err != CborNoError) {
     return err;
+  }
+  if (!cbor_value_is_map(&map)) {
+    return CborErrorIllegalType;
+  }
+
+  if (out->version) {
+    if ((err = cbor_value_map_find_value(&map, "mv", &value)) != CborNoError) {
+      return err;
+    }
+    if ((err = metrics_decode_uint(&value, &tmp)) != CborNoError) {
+      return err;
+    }
+    *out->version = (uint8_t)tmp;
+  }
+  if (out->node_id) {
+    if ((err = cbor_value_map_find_value(&map, "node", &value)) != CborNoError) {
+      return err;
+    }
+    if ((err = metrics_decode_uint(&value, out->node_id)) != CborNoError) {
+      return err;
+    }
+  }
+  if (out->uptime_ms) {
+    if ((err = cbor_value_map_find_value(&map, "up", &value)) != CborNoError) {
+      return err;
+    }
+    if ((err = metrics_decode_uint(&value, &tmp)) != CborNoError) {
+      return err;
+    }
+    *out->uptime_ms = (uint32_t)tmp;
+  }
+
+  if ((err = cbor_value_map_find_value(&map, "data", &data_map)) != CborNoError) {
+    return err;
+  }
+  if (!cbor_value_is_map(&data_map)) {
+    return CborErrorIllegalType;
+  }
+
+  for (size_t i = 0; i < out->num_components; i++) {
+    const MetricsComponentDecode *c = &out->components[i];
+    if ((err = cbor_value_map_find_value(&data_map, c->key, &comp)) != CborNoError) {
+      return err;
+    }
+    if (!cbor_value_is_valid(&comp)) {
+      continue; /* component not present in this reply */
+    }
+    if (!cbor_value_is_map(&comp)) {
+      return CborErrorIllegalType;
+    }
+    if ((err = cbor_value_enter_container(&comp, &field)) != CborNoError) {
+      return err;
+    }
+    err = bm_decode_fields_from_table(&field, c->fields, c->num_fields);
+    if (err != CborNoError && err != CborErrorUnsupportedType) {
+      return err;
+    }
+  }
+
+  return CborNoError;
 }

--- a/metrics_reply_msg.c
+++ b/metrics_reply_msg.c
@@ -8,10 +8,9 @@ CborError metrics_reply_encode(const MetricsReplyData *d, uint8_t *cbor_buffer,
   err = encoder_message_create(&encoder, &map_encoder, cbor_buffer, size,
                                METRICS_REPLY_NUM_FIELDS);
 
-  check_and_encode_key(err, encode_key_value_uint8(&map_encoder, "mv", d->version));
-  check_and_encode_key(err, cbor_encode_text_stringz(&map_encoder, "node"));
-  check_and_encode_key(err, cbor_encode_uint(&map_encoder, d->node_id));
-  check_and_encode_key(err, encode_key_value_uint32(&map_encoder, "up", d->uptime_ms));
+  check_and_encode_key(err, encode_key_value_uint8(&map_encoder, "version", d->version));
+  check_and_encode_key(err, encode_key_value_uint64(&map_encoder, "node_id", d->node_id));
+  check_and_encode_key(err, encode_key_value_uint32(&map_encoder, "uptime_ms", d->uptime_ms));
 
   // "data": { "<component key>": { <flat fields> }, ... }
   check_and_encode_key(err, cbor_encode_text_stringz(&map_encoder, "data"));
@@ -38,61 +37,40 @@ CborError metrics_reply_encode(const MetricsReplyData *d, uint8_t *cbor_buffer,
   return err;
 }
 
-static CborError metrics_decode_uint(const CborValue *value, uint64_t *out) {
-  if (!cbor_value_is_unsigned_integer(value)) {
-    return CborErrorIllegalType;
-  }
-  return cbor_value_get_uint64(value, out);
-}
-
 CborError metrics_reply_decode(const uint8_t *cbor_buffer, size_t size,
-                               const MetricsReplyDecode *out) {
+                                MetricsReplyDecode *out) {
   CborParser parser;
   CborValue map, value, data_map, comp, field;
   CborError err;
-  uint64_t tmp;
-
-  err = cbor_parser_init(cbor_buffer, size, 0, &parser, &map);
+  
+  err = decoder_message_enter(&map, &value, &parser, (uint8_t *)cbor_buffer,
+                              size, METRICS_REPLY_NUM_FIELDS);
   if (err != CborNoError) {
     return err;
   }
-  if (!cbor_value_is_map(&map)) {
-    return CborErrorIllegalType;
-  }
 
-  if (out->version) {
-    if ((err = cbor_value_map_find_value(&map, "mv", &value)) != CborNoError) {
-      return err;
-    }
-    if ((err = metrics_decode_uint(&value, &tmp)) != CborNoError) {
-      return err;
-    }
-    *out->version = (uint8_t)tmp;
-  }
-  if (out->node_id) {
-    if ((err = cbor_value_map_find_value(&map, "node", &value)) != CborNoError) {
-      return err;
-    }
-    if ((err = metrics_decode_uint(&value, out->node_id)) != CborNoError) {
-      return err;
-    }
-  }
-  if (out->uptime_ms) {
-    if ((err = cbor_value_map_find_value(&map, "up", &value)) != CborNoError) {
-      return err;
-    }
-    if ((err = metrics_decode_uint(&value, &tmp)) != CborNoError) {
-      return err;
-    }
-    *out->uptime_ms = (uint32_t)tmp;
-  }
-
-  if ((err = cbor_value_map_find_value(&map, "data", &data_map)) != CborNoError) {
+  /* metadata, decoded in wire order */
+  if ((err = decode_key_value_uint8(&out->version, &value, "version")) != CborNoError) {
     return err;
   }
-  if (!cbor_value_is_map(&data_map)) {
+  if ((err = decode_key_value_uint64(&out->node_id, &value, "node_id")) != CborNoError) {
+    return err;
+  }
+  if ((err = decode_key_value_uint32(&out->uptime_ms, &value, "uptime_ms")) != CborNoError) {
+    return err;
+  }
+
+  // "data": { "<component>": { ...flat fields... }, ... }
+  if (!cbor_value_is_text_string(&value)) {
     return CborErrorIllegalType;
   }
+  if ((err = cbor_value_advance(&value)) != CborNoError) {
+    return err;
+  }
+  if (!cbor_value_is_map(&value)) {
+    return CborErrorIllegalType;
+  }
+  data_map = value;
 
   for (size_t i = 0; i < out->num_components; i++) {
     const MetricsComponentDecode *c = &out->components[i];
@@ -113,6 +91,5 @@ CborError metrics_reply_decode(const uint8_t *cbor_buffer, size_t size,
       return err;
     }
   }
-
   return CborNoError;
 }

--- a/metrics_reply_msg.c
+++ b/metrics_reply_msg.c
@@ -1,0 +1,39 @@
+#include "metrics_reply_msg.h"
+#include "bm_messages_helper.h"
+
+CborError metrics_reply_encode(const MetricsReplyData *d, uint8_t *cbor_buffer,
+                               size_t size, size_t *encoded_len) {
+    CborError err;
+    CborEncoder encoder, map_encoder, port_array, port_map;
+
+    err = encoder_message_create(&encoder, &map_encoder, cbor_buffer, size,
+                                METRICS_REPLY_NUM_FIELDS);
+
+    check_and_encode_key(err, encode_key_value_uint8(&map_encoder, "v", d->version));
+    check_and_encode_key(err, cbor_encode_text_stringz(&map_encoder, "node"));
+    check_and_encode_key(err, cbor_encode_uint(&map_encoder, d->node_id));
+    check_and_encode_key(err, encode_key_value_uint32(&map_encoder, "up", d->uptime_ms));
+
+    // "p": [ {port0}, {port1}, ... ] 
+    check_and_encode_key(err, cbor_encode_text_stringz(&map_encoder, "p"));
+    check_and_encode_key(err, cbor_encoder_create_array(&map_encoder, &port_array, d->num_ports));
+    for (uint8_t i = 0; i < d->num_ports; i++) {
+        check_and_encode_key(err, cbor_encoder_create_map(&port_array, &port_map, METRICS_PORT_NUM_FIELDS));
+        check_and_encode_key(err, encode_key_value_uint32(&port_map, "mse", d->ports[i].mse_val));
+        check_and_encode_key(err, encode_key_value_uint8(&port_map, "sqi", d->ports[i].sqi));
+        check_and_encode_key(err, encode_key_value_uint8(&port_map, "lq",  d->ports[i].link_quality));
+        check_and_encode_key(err, encode_key_value_uint32(&port_map, "rxe", d->ports[i].rx_err_count));
+        check_and_encode_key(err, encode_key_value_uint32(&port_map, "sye", d->ports[i].symbol_err_count));
+        check_and_encode_key(err, cbor_encoder_close_container(&port_array, &port_map));
+    }
+    check_and_encode_key(err, cbor_encoder_close_container(&map_encoder, &port_array));
+
+    if (check_acceptable_encode_errors(err)) {
+        err = encoder_message_finish(&encoder, &map_encoder);
+        *encoded_len = cbor_encoder_get_buffer_size(&encoder, cbor_buffer);
+    }
+
+    encoder_message_check_memory(&encoder, err);
+
+    return err;
+}

--- a/metrics_reply_msg.c
+++ b/metrics_reply_msg.c
@@ -45,18 +45,12 @@ CborError metrics_reply_decode(const uint8_t *cbor_buffer, size_t size,
   
   err = decoder_message_enter(&map, &value, &parser, (uint8_t *)cbor_buffer,
                               size, METRICS_REPLY_NUM_FIELDS);
-  if (err != CborNoError) {
-    return err;
-  }
 
   /* metadata, decoded in wire order */
-  if ((err = decode_key_value_uint8(&out->version, &value, "version")) != CborNoError) {
-    return err;
-  }
-  if ((err = decode_key_value_uint64(&out->node_id, &value, "node_id")) != CborNoError) {
-    return err;
-  }
-  if ((err = decode_key_value_uint32(&out->uptime_ms, &value, "uptime_ms")) != CborNoError) {
+  check_and_decode_key(err, decode_key_value_uint8(&out->version, &value, "version"));
+  check_and_decode_key(err, decode_key_value_uint64(&out->node_id, &value, "node_id"));
+  check_and_decode_key(err, decode_key_value_uint32(&out->uptime_ms, &value, "uptime_ms"));
+  if (!check_acceptable_decode_errors(err)) {
     return err;
   }
 

--- a/metrics_reply_msg.h
+++ b/metrics_reply_msg.h
@@ -7,11 +7,11 @@ extern "C" {
 
 
 #define METRICS_REPLY_VERSION 1
-#define METRICS_REPLY_NUM_FIELDS 4 // mv, node, up, data
+#define METRICS_REPLY_NUM_FIELDS 4 // version, node_id, uptime_ms, data
 
 typedef struct {
   const char *key;
-  const BmEncoderTableEntry_t *fields; // filled LUT of flat metric fields
+  const BmEncoderTableEntry *fields; // filled LUT of flat metric fields
   size_t num_fields; // number of valid entries in fields
 } MetricsComponent;
 
@@ -25,14 +25,14 @@ typedef struct {
 
 typedef struct {
   const char *key;
-  const BmDecodeTableEntry_t *fields;
+  const BmDecodeTableEntry *fields;
   size_t num_fields;
 } MetricsComponentDecode;
 
 typedef struct {
-  uint8_t *version;
-  uint64_t *node_id;
-  uint32_t *uptime_ms;
+  uint8_t version;
+  uint64_t node_id;
+  uint32_t uptime_ms;
   const MetricsComponentDecode *components;
   size_t num_components;
 } MetricsReplyDecode;
@@ -41,7 +41,7 @@ CborError metrics_reply_encode(const MetricsReplyData *d, uint8_t *cbor_buffer,
                                size_t size, size_t *encoded_len);
 
 CborError metrics_reply_decode(const uint8_t *cbor_buffer, size_t size,
-                               const MetricsReplyDecode *out);
+                               MetricsReplyDecode *out);
 
 #ifdef __cplusplus
 }

--- a/metrics_reply_msg.h
+++ b/metrics_reply_msg.h
@@ -1,0 +1,34 @@
+#pragma once
+#include "cbor.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define METRICS_REPLY_VERSION 1
+#define METRICS_MAX_PORTS 2          /* ADIN2111 has 2 ports */
+#define METRICS_REPLY_NUM_FIELDS 4   /* v, node, up, p */
+#define METRICS_PORT_NUM_FIELDS 5    /* mse, sqi, lq, rxe, sye */
+
+typedef struct {
+  uint16_t mse_val;          /* raw MSE_VAL register */
+  uint8_t  sqi;              /* signal quality indicator */
+  uint8_t  link_quality;     /* adi_phy_LinkQuality_e: 0 poor / 1 marginal / 2 good */
+  uint16_t rx_err_count;     /* frame_check_rx_error_count */
+  uint16_t symbol_err_count; /* frame_check_error_counters.SYMB_ERR_CNT */
+} MetricsPortStats;
+
+typedef struct {
+  uint8_t  version;
+  uint64_t node_id;
+  uint32_t uptime_ms;
+  uint8_t  num_ports;
+  MetricsPortStats ports[METRICS_MAX_PORTS];
+} MetricsReplyData;
+
+CborError metrics_reply_encode(const MetricsReplyData *d, uint8_t *cbor_buffer,
+                               size_t size, size_t *encoded_len);
+
+#ifdef __cplusplus
+}
+#endif

--- a/metrics_reply_msg.h
+++ b/metrics_reply_msg.h
@@ -1,33 +1,47 @@
 #pragma once
-#include "cbor.h"
+#include "bm_messages_helper.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+
 #define METRICS_REPLY_VERSION 1
-#define METRICS_MAX_PORTS 2          /* ADIN2111 has 2 ports */
-#define METRICS_REPLY_NUM_FIELDS 4   /* v, node, up, p */
-#define METRICS_PORT_NUM_FIELDS 5    /* mse, sqi, lq, rxe, sye */
+#define METRICS_REPLY_NUM_FIELDS 4 // mv, node, up, data
 
 typedef struct {
-  uint16_t mse_val;          /* raw MSE_VAL register */
-  uint8_t  sqi;              /* signal quality indicator */
-  uint8_t  link_quality;     /* adi_phy_LinkQuality_e: 0 poor / 1 marginal / 2 good */
-  uint16_t rx_err_count;     /* frame_check_rx_error_count */
-  uint16_t symbol_err_count; /* frame_check_error_counters.SYMB_ERR_CNT */
-} MetricsPortStats;
+  const char *key;
+  const BmEncoderTableEntry_t *fields; // filled LUT of flat metric fields
+  size_t num_fields; // number of valid entries in fields
+} MetricsComponent;
 
 typedef struct {
-  uint8_t  version;
+  uint8_t version;
   uint64_t node_id;
   uint32_t uptime_ms;
-  uint8_t  num_ports;
-  MetricsPortStats ports[METRICS_MAX_PORTS];
+  const MetricsComponent *components;
+  size_t num_components;
 } MetricsReplyData;
+
+typedef struct {
+  const char *key;
+  const BmDecodeTableEntry_t *fields;
+  size_t num_fields;
+} MetricsComponentDecode;
+
+typedef struct {
+  uint8_t *version;
+  uint64_t *node_id;
+  uint32_t *uptime_ms;
+  const MetricsComponentDecode *components;
+  size_t num_components;
+} MetricsReplyDecode;
 
 CborError metrics_reply_encode(const MetricsReplyData *d, uint8_t *cbor_buffer,
                                size_t size, size_t *encoded_len);
+
+CborError metrics_reply_decode(const uint8_t *cbor_buffer, size_t size,
+                               const MetricsReplyDecode *out);
 
 #ifdef __cplusplus
 }

--- a/msg/metrics_reply.msg
+++ b/msg/metrics_reply.msg
@@ -1,6 +1,4 @@
-import network_port_stats
-
 uint8 version
 uint64 node_id
 uint32 uptime_ms
-network_port_stats data
+cbor_map data

--- a/msg/metrics_reply.msg
+++ b/msg/metrics_reply.msg
@@ -1,0 +1,6 @@
+import network_port_stats
+
+uint8 version
+uint64 node_id
+uint32 uptime_ms
+network_port_stats data

--- a/msg/network_port_stats.msg
+++ b/msg/network_port_stats.msg
@@ -1,0 +1,9 @@
+uint8 num_ports
+uint8 sqi[]
+uint16 mse[]
+uint8 lq[]
+uint16 rxe[]
+uint16 sye[]
+uint16 fc[]
+uint16 len[]
+uint16 algn[]

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -69,6 +69,7 @@ set(BM_COMMON_MESSAGES_SRCS
     ${SRC_DIR}/power_solar_averages_msg.cpp
     ${SRC_DIR}/aanderaa_conductivity_msg.cpp
     ${SRC_DIR}/aanderaa_current_meter_msg.cpp
+    ${SRC_DIR}/metrics_reply_msg.c 
 
     # support files
     ${SRC_DIR}/third_party/tinycbor/src/cborparser.c

--- a/test/bm_common_messages_tests_ut.cpp
+++ b/test/bm_common_messages_tests_ut.cpp
@@ -13,6 +13,7 @@
 #include "config_cbor_map_srv_request_msg.h"
 #include "device_test_svc_reply_msg.h"
 #include "device_test_svc_request_msg.h"
+#include "metrics_reply_msg.h"
 #include "pme_dissolved_oxygen_msg.h"
 #include "pme_wipe_msg.h"
 #include "power_battery_averages_msg.h"
@@ -1607,4 +1608,208 @@ TEST_F(BmCommonTest, BmEncodeFieldsFromTableUnsupportedTypeTest) {
   err = bm_encode_fields_from_table(
       &map_encoder, encode_table, sizeof(encode_table) / sizeof(encode_table[0]));
   EXPECT_EQ(err, CborErrorUnsupportedType);
+}
+
+TEST_F(BmCommonTest, MetricsReplyEncodeDecodeEnvelope) {
+  uint8_t num_ports = 1;
+  uint8_t sqi_1 = 5;
+  uint16_t mse_1 = 1234;
+
+  BmEncoderTableEntry enc_fields[3];
+  enc_fields[0] = {"num_ports", BM_FIELD_UINT8, &num_ports};
+  enc_fields[1] = {"sqi_1", BM_FIELD_UINT8, &sqi_1};
+  enc_fields[2] = {"mse_1", BM_FIELD_UINT16, &mse_1};
+
+  MetricsComponent comp = {};
+  comp.key = "network_port_stats";
+  comp.fields = enc_fields;
+  comp.num_fields = 3;
+
+  MetricsReplyData d = {};
+  d.version = METRICS_REPLY_VERSION;
+  d.node_id = 0x0123456789abcdefULL;
+  d.uptime_ms = 42000;
+  d.components = &comp;
+  d.num_components = 1;
+
+  uint8_t cbor_buffer[256];
+  size_t len = 0;
+  EXPECT_EQ(metrics_reply_encode(&d, cbor_buffer, sizeof(cbor_buffer), &len), CborNoError);
+  EXPECT_EQ(len, 93);
+
+  uint8_t got_num_ports = 0;
+  uint8_t got_sqi = 0;
+  uint16_t got_mse = 0;
+
+  BmDecodeTableEntry dec_fields[3];
+  dec_fields[0] = {"num_ports", BM_FIELD_UINT8, &got_num_ports};
+  dec_fields[1] = {"sqi_1", BM_FIELD_UINT8, &got_sqi};
+  dec_fields[2] = {"mse_1", BM_FIELD_UINT16, &got_mse};
+
+  MetricsComponentDecode dcomp = {};
+  dcomp.key = "network_port_stats";
+  dcomp.fields = dec_fields;
+  dcomp.num_fields = 3;
+
+  MetricsReplyDecode out = {};
+  out.components = &dcomp;
+  out.num_components = 1;
+
+  EXPECT_EQ(metrics_reply_decode(cbor_buffer, len, &out), CborNoError);
+  EXPECT_EQ(out.version, (uint8_t)METRICS_REPLY_VERSION);
+  EXPECT_EQ(out.node_id, d.node_id);
+  EXPECT_EQ(out.uptime_ms, d.uptime_ms);
+  EXPECT_EQ(got_num_ports, num_ports);
+  EXPECT_EQ(got_sqi, sqi_1);
+  EXPECT_EQ(got_mse, mse_1);
+}
+
+TEST_F(BmCommonTest, MetricsReplyDecodeSkipsAbsentComponent) {
+  MetricsReplyData d = {};
+  d.version = METRICS_REPLY_VERSION;
+  d.node_id = 1;
+  d.uptime_ms = 0;
+  d.components = NULL;
+  d.num_components = 0;
+
+  uint8_t cbor_buffer[64];
+  size_t len = 0;
+  EXPECT_EQ(metrics_reply_encode(&d, cbor_buffer, sizeof(cbor_buffer), &len), CborNoError);
+
+  uint8_t got_num_ports = 0xAA;
+  BmDecodeTableEntry dec_fields[1];
+  dec_fields[0] = {"num_ports", BM_FIELD_UINT8, &got_num_ports};
+
+  MetricsComponentDecode dcomp = {};
+  dcomp.key = "network_port_stats";
+  dcomp.fields = dec_fields;
+  dcomp.num_fields = 1;
+
+  MetricsReplyDecode out = {};
+  out.components = &dcomp;
+  out.num_components = 1;
+
+  EXPECT_EQ(metrics_reply_decode(cbor_buffer, len, &out), CborNoError);
+  EXPECT_EQ(out.version, (uint8_t)METRICS_REPLY_VERSION);
+  EXPECT_EQ(out.node_id, 1u);
+  EXPECT_EQ(got_num_ports, 0xAA); // untouched: component absent
+}
+
+TEST_F(BmCommonTest, MetricsReplyMultipleComponentsAndPorts) {
+  uint8_t num_ports = 2;
+  uint8_t sqi_1 = 7, sqi_2 = 6;
+  uint16_t mse_1 = 100, mse_2 = 200;
+
+  BmEncoderTableEntry net_fields[5];
+  net_fields[0] = {"num_ports", BM_FIELD_UINT8, &num_ports};
+  net_fields[1] = {"sqi_1", BM_FIELD_UINT8, &sqi_1};
+  net_fields[2] = {"mse_1", BM_FIELD_UINT16, &mse_1};
+  net_fields[3] = {"sqi_2", BM_FIELD_UINT8, &sqi_2};
+  net_fields[4] = {"mse_2", BM_FIELD_UINT16, &mse_2};
+
+  // Second component is synthetic (no such producer exists)
+  uint32_t heap_free = 54321;
+  BmEncoderTableEntry sys_fields[1];
+  sys_fields[0] = {"heap_free", BM_FIELD_UINT32, &heap_free};
+
+  MetricsComponent comps[2] = {};
+  comps[0].key = "network_port_stats";
+  comps[0].fields = net_fields;
+  comps[0].num_fields = 5;
+  comps[1].key = "sys_stats";
+  comps[1].fields = sys_fields;
+  comps[1].num_fields = 1;
+
+  MetricsReplyData d = {};
+  d.version = METRICS_REPLY_VERSION;
+  d.node_id = 0xdeadbeefcafef00dULL;
+  d.uptime_ms = 7;
+  d.components = comps;
+  d.num_components = 2;
+
+  uint8_t cbor_buffer[512];
+  size_t len = 0;
+  EXPECT_EQ(metrics_reply_encode(&d, cbor_buffer, sizeof(cbor_buffer), &len), CborNoError);
+  EXPECT_EQ(len, 129);
+
+  uint8_t got_num_ports = 0, got_sqi_1 = 0, got_sqi_2 = 0;
+  uint16_t got_mse_1 = 0, got_mse_2 = 0;
+  uint32_t got_heap = 0;
+
+  BmDecodeTableEntry net_dec[5];
+  net_dec[0] = {"num_ports", BM_FIELD_UINT8, &got_num_ports};
+  net_dec[1] = {"sqi_1", BM_FIELD_UINT8, &got_sqi_1};
+  net_dec[2] = {"mse_1", BM_FIELD_UINT16, &got_mse_1};
+  net_dec[3] = {"sqi_2", BM_FIELD_UINT8, &got_sqi_2};
+  net_dec[4] = {"mse_2", BM_FIELD_UINT16, &got_mse_2};
+
+  BmDecodeTableEntry sys_dec[1];
+  sys_dec[0] = {"heap_free", BM_FIELD_UINT32, &got_heap};
+
+  MetricsComponentDecode dcomps[2] = {};
+  dcomps[0].key = "sys_stats";
+  dcomps[0].fields = sys_dec;
+  dcomps[0].num_fields = 1;
+  dcomps[1].key = "network_port_stats";
+  dcomps[1].fields = net_dec;
+  dcomps[1].num_fields = 5;
+
+  MetricsReplyDecode out = {};
+  out.components = dcomps;
+  out.num_components = 2;
+
+  EXPECT_EQ(metrics_reply_decode(cbor_buffer, len, &out), CborNoError);
+  EXPECT_EQ(out.node_id, d.node_id);
+  EXPECT_EQ(got_num_ports, 2);
+  EXPECT_EQ(got_sqi_1, 7);
+  EXPECT_EQ(got_sqi_2, 6);
+  EXPECT_EQ(got_mse_1, 100);
+  EXPECT_EQ(got_mse_2, 200);
+  EXPECT_EQ(got_heap, 54321u);
+}
+
+TEST_F(BmCommonTest, MetricsReplyDecodeToleratesExtraComponentFields) {
+  uint8_t num_ports = 1;
+  uint8_t sqi_1 = 9;
+  uint16_t mse_1 = 4321;
+
+  BmEncoderTableEntry enc_fields[3];
+  enc_fields[0] = {"num_ports", BM_FIELD_UINT8, &num_ports};
+  enc_fields[1] = {"sqi_1", BM_FIELD_UINT8, &sqi_1};
+  enc_fields[2] = {"mse_1", BM_FIELD_UINT16, &mse_1};
+
+  MetricsComponent comp = {};
+  comp.key = "network_port_stats";
+  comp.fields = enc_fields;
+  comp.num_fields = 3;
+
+  MetricsReplyData d = {};
+  d.version = METRICS_REPLY_VERSION;
+  d.node_id = 2;
+  d.uptime_ms = 5;
+  d.components = &comp;
+  d.num_components = 1;
+
+  uint8_t cbor_buffer[256];
+  size_t len = 0;
+  EXPECT_EQ(metrics_reply_encode(&d, cbor_buffer, sizeof(cbor_buffer), &len), CborNoError);
+
+  // Decoder only knows about num_ports and sqi_1; mse_1 is "new".
+  uint8_t got_num_ports = 0, got_sqi = 0;
+  BmDecodeTableEntry dec_fields[2];
+  dec_fields[0] = {"num_ports", BM_FIELD_UINT8, &got_num_ports};
+  dec_fields[1] = {"sqi_1", BM_FIELD_UINT8, &got_sqi};
+
+  MetricsComponentDecode dcomp = {};
+  dcomp.key = "network_port_stats";
+  dcomp.fields = dec_fields;
+  dcomp.num_fields = 2;
+
+  MetricsReplyDecode out = {};
+  out.components = &dcomp;
+  out.num_components = 1;
+
+  EXPECT_EQ(metrics_reply_decode(cbor_buffer, len, &out), CborNoError);
+  EXPECT_EQ(got_num_ports, num_ports);
+  EXPECT_EQ(got_sqi, sqi_1);
 }


### PR DESCRIPTION
## What changed?
Adds the CBOR schema and encoder for the metrics reply message. The message is transport-agnostic and driver-independent; it depends only on TinyCBOR and bm_messages_helper.

## How does it make Bristlemouth better?
This establishes the schema layer for the network-metrics feature, kept deliberately separate from how it's collected (the service, in bm_core) and how it's transported. The explicit version field lets the schema evolve without breaking existing decoders.


## Where should reviewers focus?



## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.